### PR TITLE
Implement core plugin features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# myth_of_five
+# Myth of Five
+
+이 저장소는 설화전(Mystic War) 마인크래프트 플러그인을 위한 최소 기능 사양과 구현을 포함합니다.
+자세한 기능 요구 사항은 [SPEC.md](SPEC.md) 파일을 참고하세요.
+
+## Build
+
+Maven을 사용해 플러그인을 빌드합니다.
+
+```bash
+mvn package
+```
+
+생성된 JAR 파일은 `target/` 디렉터리에서 확인할 수 있습니다.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,94 @@
+# 설화전 플러그인 최소 기능 사양
+
+## A) 도깨비 보스
+
+### 1. 관리자 명령
+- `/myth admin spawnboss <이름:도깨비> [hp] [armor] [world] [x y z]`
+- `/myth admin bosslist`
+- `/myth admin endboss <bossId>`
+  - 권한: `myth.admin.*`
+
+### 2. 방송(채팅)
+- 소환: `「[방송] 태초의 도깨비가 나타났다!」`
+- 처치: `「[방송] <플레이어>가 태초의 도깨비를 쓰러뜨리고 힘을 계승했다!」`
+
+### 3. 기본 동작
+- 소환 시 보스바 출력, 체력 및 방어력 적용.
+- 마지막 일격을 가한 플레이어를 단일 계승자로 지정.
+- 이미 계승 중인 플레이어가 다시 처치해도 갱신만 수행.
+- 이벤트 기록 키 예시: `BOSS_SPAWNED`, `BOSS_DEFEATED`, `MYTH_INHERITED`.
+
+## B) 계승 & 소멸
+
+### 1. 계승
+- 보스 처치 직후 계승자에게 “도깨비 힘” 부여.
+- 상태 플래그: `isInheritor=true`, `powerKey="dokkaebi.core"`.
+- 즉시 방송 및 보스바 종료.
+
+### 2. 소멸
+- 계승자가 다른 플레이어에게 사망 시 즉시 능력 삭제.
+- 방송: `「[방송] <계승자>가 쓰러져 도깨비의 힘이 사라졌다.」`
+- 상태 플래그 초기화: `isInheritor=false`, `powerKey=null`.
+
+### 3. 충돌 처리
+- 서버 리스타트나 로그인 시 상태 재적용 필요.
+- 동일 틱 다중 이벤트 대비 토큰으로 중복 부여/제거 방지.
+- 이벤트 기록 키: `MYTH_LOST`.
+
+## C) 부대(Squad)
+
+### 1. 일반 명령
+- `/squad create <이름>`
+- `/squad invite <플레이어>`
+- `/squad accept <부대>`
+- `/squad leave`
+- `/squad disband`
+- `/squad status`
+  - 권한: `myth.user.squad.*`
+
+### 2. 규칙
+- 부대장은 생성자이며 계승 여부와 무관.
+- 최대 인원은 설정값(기본 5).
+- 부대원 목록 및 온라인 수 상태표시 제공.
+- 우호 피해 옵션을 on/off 설정 가능.
+
+### 3. 알림
+- 초대: `「<보낸이>가 <받는이>를 부대에 초대했습니다. /squad accept 로 수락」`
+- 가입, 탈퇴, 해산 시 간단 방송 출력.
+- 이벤트 기록 키: `SQUAD_CREATED`, `SQUAD_INVITED`, `SQUAD_JOINED`, `SQUAD_LEFT`, `SQUAD_DISBANDED`.
+
+## D) 설정(config.yml 키)
+```
+boss:
+  hp_default: 10000
+  armor_default: 50
+  name: "태초의 도깨비"
+inherit:
+  power_key: "dokkaebi.core"
+  buffs:
+    - "speed:1"
+    - "strength:1"
+  announce: true
+squad:
+  max_members: 5
+  friendly_fire: false
+```
+
+## E) 권한 요약
+- `myth.admin.*` — spawnboss, bosslist, endboss
+- `myth.user.squad.*` — create, invite, accept, leave, disband, status
+
+## F) 확인 시나리오
+
+### 시나리오 1 — 계승
+1. `/myth admin spawnboss 도깨비 10000 50 world 0 80 0`
+2. 플레이어 A가 보스 처치 → A가 계승자 지정, 버프 적용, 방송 출력.
+
+### 시나리오 2 — 소멸
+1. 계승자 A가 PvP로 사망.
+2. 능력 즉시 제거, `isInheritor=false`, 방송 출력.
+
+### 시나리오 3 — 부대
+1. 플레이어 B가 `/squad create 늑대들` 실행 후 `/squad invite C`.
+2. 플레이어 C가 `/squad accept 늑대들` 후 `/squad status`로 인원 확인.
+3. `/squad leave`, `/squad disband` 동작 확인.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mythof5</groupId>
+    <artifactId>myth-of-five</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>MythOfFive</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/mythof5/MythCommand.java
+++ b/src/main/java/com/mythof5/MythCommand.java
@@ -1,0 +1,70 @@
+package com.mythof5;
+
+import com.mythof5.boss.BossManager;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class MythCommand implements CommandExecutor {
+    private final BossManager bossManager;
+
+    public MythCommand(BossManager bossManager) {
+        this.bossManager = bossManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length < 1 || !args[0].equalsIgnoreCase("admin")) {
+            return false;
+        }
+        if (!sender.hasPermission("myth.admin")) {
+            sender.sendMessage("No permission");
+            return true;
+        }
+        if (args.length < 2) {
+            sender.sendMessage("Usage: /myth admin <spawnboss|bosslist|endboss>");
+            return true;
+        }
+        String sub = args[1];
+        switch (sub.toLowerCase()) {
+            case "spawnboss":
+                if (args.length < 9) {
+                    sender.sendMessage("Usage: /myth admin spawnboss <name> <hp> <armor> <world> <x> <y> <z>");
+                    return true;
+                }
+                String name = args[2];
+                double hp = Double.parseDouble(args[3]);
+                double armor = Double.parseDouble(args[4]);
+                World world = Bukkit.getWorld(args[5]);
+                double x = Double.parseDouble(args[6]);
+                double y = Double.parseDouble(args[7]);
+                double z = Double.parseDouble(args[8]);
+                if (world == null) {
+                    sender.sendMessage("World not found");
+                    return true;
+                }
+                int id = bossManager.spawnBoss(name, hp, armor, world, x, y, z);
+                sender.sendMessage("Spawned boss id " + id);
+                return true;
+            case "bosslist":
+                bossManager.getBosses().forEach((i, info) -> sender.sendMessage(i + ": " + info.entity.getType() + " at " + info.entity.getLocation()));
+                return true;
+            case "endboss":
+                if (args.length < 3) {
+                    sender.sendMessage("Usage: /myth admin endboss <id>");
+                    return true;
+                }
+                int bid = Integer.parseInt(args[2]);
+                if (bossManager.endBoss(bid)) {
+                    sender.sendMessage("Boss removed");
+                } else {
+                    sender.sendMessage("Boss not found");
+                }
+                return true;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/mythof5/MythPlugin.java
+++ b/src/main/java/com/mythof5/MythPlugin.java
@@ -1,0 +1,47 @@
+package com.mythof5;
+
+import com.mythof5.boss.BossManager;
+import com.mythof5.inherit.InheritanceListener;
+import com.mythof5.squad.SquadCommand;
+import com.mythof5.squad.SquadManager;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class MythPlugin extends JavaPlugin {
+    private static MythPlugin instance;
+    private BossManager bossManager;
+    private SquadManager squadManager;
+
+    public static MythPlugin getInstance() {
+        return instance;
+    }
+
+    @Override
+    public void onEnable() {
+        instance = this;
+        saveDefaultConfig();
+        bossManager = new BossManager(this);
+        squadManager = new SquadManager(this);
+
+        getCommand("myth").setExecutor(new MythCommand(bossManager));
+        SquadCommand squadCommand = new SquadCommand(squadManager);
+        getCommand("squad").setExecutor(squadCommand);
+        getCommand("squad").setTabCompleter(squadCommand);
+
+        Bukkit.getPluginManager().registerEvents(new InheritanceListener(bossManager, squadManager), this);
+    }
+
+    @Override
+    public void onDisable() {
+        bossManager.clearBosses();
+    }
+
+    public FileConfiguration getConfiguration() {
+        return getConfig();
+    }
+
+    public SquadManager getSquadManager() {
+        return squadManager;
+    }
+}

--- a/src/main/java/com/mythof5/boss/BossManager.java
+++ b/src/main/java/com/mythof5/boss/BossManager.java
@@ -1,0 +1,112 @@
+package com.mythof5.boss;
+
+import com.mythof5.MythPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BossManager {
+    private final MythPlugin plugin;
+
+    /**
+     * Stores all active bosses. Each boss has an id, entity and bossbar.
+     */
+    public static class BossInfo {
+        public final LivingEntity entity;
+        public final BossBar bar;
+
+        public BossInfo(LivingEntity entity, BossBar bar) {
+            this.entity = entity;
+            this.bar = bar;
+        }
+    }
+
+    private final Map<Integer, BossInfo> bosses = new HashMap<>();
+    private final AtomicInteger ids = new AtomicInteger();
+
+    public BossManager(MythPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public int spawnBoss(String name, double hp, double armor, World world, double x, double y, double z) {
+        LivingEntity entity = (LivingEntity) world.spawnEntity(new org.bukkit.Location(world, x, y, z), EntityType.ZOMBIE);
+        entity.setCustomName(name);
+        entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(hp);
+        entity.setHealth(hp);
+        entity.getAttribute(Attribute.GENERIC_ARMOR).setBaseValue(armor);
+        entity.setRemoveWhenFarAway(false);
+
+        BossBar bar = Bukkit.createBossBar(name, BarColor.RED, BarStyle.SOLID);
+        bar.setProgress(1.0);
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            bar.addPlayer(p);
+        }
+
+        int id = ids.incrementAndGet();
+        bosses.put(id, new BossInfo(entity, bar));
+        Bukkit.broadcastMessage("[방송] 태초의 도깨비가 나타났다!");
+        plugin.getLogger().info("BOSS_SPAWNED id=" + id);
+        return id;
+    }
+
+    public Map<Integer, BossInfo> getBosses() {
+        return bosses;
+    }
+
+    public boolean endBoss(int id) {
+        BossInfo info = bosses.remove(id);
+        if (info != null) {
+            info.bar.removeAll();
+            info.entity.remove();
+            plugin.getLogger().info("BOSS_DEFEATED id=" + id);
+            return true;
+        }
+        return false;
+    }
+
+    public Integer getBossId(Entity entity) {
+        for (Map.Entry<Integer, BossInfo> entry : bosses.entrySet()) {
+            if (entry.getValue().entity.getUniqueId().equals(entity.getUniqueId())) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Update the bossbar progress for the given entity.
+     */
+    public void updateBossBar(LivingEntity entity) {
+        Integer id = getBossId(entity);
+        if (id != null) {
+            BossInfo info = bosses.get(id);
+            double max = entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+            info.bar.setProgress(Math.max(0, entity.getHealth() / max));
+        }
+    }
+
+    public void addPlayer(Player player) {
+        for (BossInfo info : bosses.values()) {
+            info.bar.addPlayer(player);
+        }
+    }
+
+    public void clearBosses() {
+        for (BossInfo info : bosses.values()) {
+            info.bar.removeAll();
+            info.entity.remove();
+        }
+        bosses.clear();
+    }
+}

--- a/src/main/java/com/mythof5/inherit/InheritanceListener.java
+++ b/src/main/java/com/mythof5/inherit/InheritanceListener.java
@@ -1,0 +1,143 @@
+package com.mythof5.inherit;
+
+import com.mythof5.MythPlugin;
+import com.mythof5.boss.BossManager;
+import com.mythof5.squad.SquadManager;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class InheritanceListener implements Listener {
+    private final BossManager bossManager;
+    private final SquadManager squadManager;
+    private final MythPlugin plugin = MythPlugin.getInstance();
+    private final String powerKey;
+    private UUID inheritor;
+    private final List<PotionEffect> effects = new ArrayList<>();
+
+    public InheritanceListener(BossManager bossManager, SquadManager squadManager) {
+        this.bossManager = bossManager;
+        this.squadManager = squadManager;
+        FileConfiguration cfg = plugin.getConfiguration();
+        powerKey = cfg.getString("inherit.power_key");
+        if (cfg.contains("inherit.current")) {
+            inheritor = UUID.fromString(cfg.getString("inherit.current"));
+        }
+        loadEffects();
+        if (inheritor != null) {
+            Player p = Bukkit.getPlayer(inheritor);
+            if (p != null && p.isOnline()) {
+                applyEffects(p);
+            }
+        }
+    }
+
+    private void loadEffects() {
+        FileConfiguration cfg = plugin.getConfiguration();
+        for (String s : cfg.getStringList("inherit.buffs")) {
+            String[] split = s.split(":");
+            PotionEffectType type = PotionEffectType.getByName(split[0].toUpperCase());
+            int level = Integer.parseInt(split[1]);
+            effects.add(new PotionEffect(type, Integer.MAX_VALUE, level - 1));
+        }
+    }
+
+    private void applyEffects(Player player) {
+        for (PotionEffect effect : effects) {
+            player.addPotionEffect(effect);
+        }
+        player.addScoreboardTag("myth_inheritor");
+        player.getPersistentDataContainer().set(new NamespacedKey(plugin, "powerKey"), PersistentDataType.STRING, powerKey);
+    }
+
+    private void clearEffects(Player player) {
+        for (PotionEffect effect : effects) {
+            player.removePotionEffect(effect.getType());
+        }
+        player.removeScoreboardTag("myth_inheritor");
+        player.getPersistentDataContainer().remove(new NamespacedKey(plugin, "powerKey"));
+    }
+
+    @EventHandler
+    public void onBossDeath(EntityDeathEvent event) {
+        Integer id = bossManager.getBossId(event.getEntity());
+        if (id != null) {
+            Player killer = event.getEntity().getKiller();
+            bossManager.endBoss(id);
+            if (killer != null) {
+                inheritor = killer.getUniqueId();
+                applyEffects(killer);
+                plugin.getConfiguration().set("inherit.current", inheritor.toString());
+                plugin.saveConfig();
+                plugin.getLogger().info("MYTH_INHERITED player=" + killer.getName());
+                if (plugin.getConfiguration().getBoolean("inherit.announce", true)) {
+                    Bukkit.broadcastMessage("[방송] " + killer.getName() + "가 태초의 도깨비를 쓰러뜨리고 힘을 계승했다!");
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        if (inheritor != null && player.getUniqueId().equals(inheritor)) {
+            clearEffects(player);
+            inheritor = null;
+            plugin.getConfiguration().set("inherit.current", null);
+            plugin.saveConfig();
+            plugin.getLogger().info("MYTH_LOST player=" + player.getName());
+            if (plugin.getConfiguration().getBoolean("inherit.announce", true)) {
+                Bukkit.broadcastMessage("[방송] " + player.getName() + "가 쓰러져 도깨비의 힘이 사라졌다.");
+            }
+        }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        bossManager.addPlayer(player);
+        if (inheritor != null && player.getUniqueId().equals(inheritor)) {
+            applyEffects(player);
+        }
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event) {
+        Entity damager = event.getDamager();
+        Entity victim = event.getEntity();
+        if (damager instanceof Player && victim instanceof Player) {
+            Player p1 = (Player) damager;
+            Player p2 = (Player) victim;
+            if (!MythPlugin.getInstance().getConfiguration().getBoolean("squad.friendly_fire")
+                    && squadManager.sameSquad(p1.getUniqueId(), p2.getUniqueId())) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onBossDamage(EntityDamageEvent event) {
+        if (event.getEntity() instanceof org.bukkit.entity.LivingEntity) {
+            Integer id = bossManager.getBossId(event.getEntity());
+            if (id != null) {
+                bossManager.updateBossBar((org.bukkit.entity.LivingEntity) event.getEntity());
+            }
+        }
+    }
+}

--- a/src/main/java/com/mythof5/squad/SquadCommand.java
+++ b/src/main/java/com/mythof5/squad/SquadCommand.java
@@ -1,0 +1,97 @@
+package com.mythof5.squad;
+
+import com.mythof5.MythPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SquadCommand implements CommandExecutor, TabCompleter {
+    private final SquadManager manager;
+
+    public SquadCommand(SquadManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Players only");
+            return true;
+        }
+        Player player = (Player) sender;
+        int maxMembers = MythPlugin.getInstance().getConfiguration().getInt("squad.max_members");
+        if (args.length == 0) {
+            sender.sendMessage("Usage: /squad <create|invite|accept|leave|disband|status>");
+            return true;
+        }
+        switch (args[0].toLowerCase()) {
+            case "create":
+                if (args.length < 2) {
+                    sender.sendMessage("/squad create <name>");
+                    return true;
+                }
+                if (!manager.createSquad(args[1], player, maxMembers)) {
+                    sender.sendMessage("부대를 만들 수 없습니다.");
+                }
+                return true;
+            case "invite":
+                if (args.length < 2) {
+                    sender.sendMessage("/squad invite <player>");
+                    return true;
+                }
+                Player target = Bukkit.getPlayer(args[1]);
+                if (target == null) {
+                    sender.sendMessage("플레이어를 찾을 수 없습니다.");
+                    return true;
+                }
+                if (!manager.invite(player, target)) {
+                    sender.sendMessage("초대할 수 없습니다.");
+                }
+                return true;
+            case "accept":
+                if (args.length < 2) {
+                    sender.sendMessage("/squad accept <squad>");
+                    return true;
+                }
+                if (!manager.accept(player, args[1])) {
+                    sender.sendMessage("초대를 찾을 수 없거나 인원이 가득 찼습니다.");
+                }
+                return true;
+            case "leave":
+                if (!manager.leave(player)) {
+                    sender.sendMessage("부대에 속해있지 않습니다.");
+                }
+                return true;
+            case "disband":
+                if (!manager.disband(player)) {
+                    sender.sendMessage("부대를 해산할 수 없습니다.");
+                }
+                return true;
+            case "status":
+                sender.sendMessage(manager.status(player));
+                return true;
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> list = new ArrayList<>();
+        if (args.length == 1) {
+            list.add("create");
+            list.add("invite");
+            list.add("accept");
+            list.add("leave");
+            list.add("disband");
+            list.add("status");
+        }
+        return list;
+    }
+}

--- a/src/main/java/com/mythof5/squad/SquadManager.java
+++ b/src/main/java/com/mythof5/squad/SquadManager.java
@@ -1,0 +1,122 @@
+package com.mythof5.squad;
+
+import com.mythof5.MythPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.*;
+
+public class SquadManager {
+    private final Map<String, Squad> squads = new HashMap<>();
+    private final Map<UUID, Squad> membership = new HashMap<>();
+    private final Map<UUID, String> invites = new HashMap<>();
+    private final MythPlugin plugin;
+
+    public SquadManager(MythPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public boolean createSquad(String name, Player owner, int maxMembers) {
+        if (squads.containsKey(name) || membership.containsKey(owner.getUniqueId())) return false;
+        Squad squad = new Squad(name, owner.getUniqueId(), maxMembers);
+        squad.members.add(owner.getUniqueId());
+        squads.put(name, squad);
+        membership.put(owner.getUniqueId(), squad);
+        Bukkit.broadcastMessage(owner.getName() + "가 부대 " + name + "를 생성했습니다.");
+        plugin.getLogger().info("SQUAD_CREATED name=" + name);
+        return true;
+    }
+
+    public boolean invite(Player sender, Player target) {
+        Squad squad = membership.get(sender.getUniqueId());
+        if (squad == null || !squad.owner.equals(sender.getUniqueId())) return false;
+        invites.put(target.getUniqueId(), squad.name);
+        target.sendMessage(sender.getName() + "가 당신을 부대에 초대했습니다. /squad accept " + squad.name + " 로 수락");
+        plugin.getLogger().info("SQUAD_INVITED from=" + sender.getName() + " to=" + target.getName());
+        return true;
+    }
+
+    public boolean accept(Player player, String squadName) {
+        String invite = invites.get(player.getUniqueId());
+        Squad squad = squads.get(squadName);
+        if (invite == null || !invite.equals(squadName) || squad == null) return false;
+        if (squad.members.size() >= squad.maxMembers) return false;
+        squad.members.add(player.getUniqueId());
+        membership.put(player.getUniqueId(), squad);
+        invites.remove(player.getUniqueId());
+        Bukkit.broadcastMessage(player.getName() + "가 부대 " + squad.name + "에 합류했습니다.");
+        plugin.getLogger().info("SQUAD_JOINED player=" + player.getName() + " squad=" + squad.name);
+        return true;
+    }
+
+    public boolean leave(Player player) {
+        Squad squad = membership.get(player.getUniqueId());
+        if (squad == null) return false;
+        if (squad.owner.equals(player.getUniqueId())) {
+            disband(player);
+            return true;
+        }
+        squad.members.remove(player.getUniqueId());
+        membership.remove(player.getUniqueId());
+        Bukkit.broadcastMessage(player.getName() + "가 부대 " + squad.name + "에서 탈퇴했습니다.");
+        plugin.getLogger().info("SQUAD_LEFT player=" + player.getName() + " squad=" + squad.name);
+        return true;
+    }
+
+    public boolean disband(Player player) {
+        Squad squad = membership.get(player.getUniqueId());
+        if (squad == null || !squad.owner.equals(player.getUniqueId())) return false;
+        for (UUID uuid : squad.members) {
+            membership.remove(uuid);
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null) {
+                p.sendMessage("부대 " + squad.name + "가 해산되었습니다.");
+            }
+        }
+        squads.remove(squad.name);
+        Bukkit.broadcastMessage("부대 " + squad.name + "가 해산되었습니다.");
+        plugin.getLogger().info("SQUAD_DISBANDED name=" + squad.name);
+        return true;
+    }
+
+    public String status(Player player) {
+        Squad squad = membership.get(player.getUniqueId());
+        if (squad == null) return "당신은 어떤 부대에도 속해있지 않습니다.";
+        StringBuilder sb = new StringBuilder();
+        sb.append("부대 ").append(squad.name).append(" 멤버: ");
+        for (UUID uuid : squad.members) {
+            Player p = Bukkit.getPlayer(uuid);
+            sb.append(p != null && p.isOnline() ? p.getName() : Bukkit.getOfflinePlayer(uuid).getName()).append(" ");
+        }
+        sb.append("(온라인 ").append(squad.onlineCount()).append("/").append(squad.members.size()).append(")");
+        return sb.toString();
+    }
+
+    public boolean sameSquad(UUID a, UUID b) {
+        Squad sa = membership.get(a);
+        Squad sb = membership.get(b);
+        return sa != null && sa == sb;
+    }
+
+    private static class Squad {
+        final String name;
+        final UUID owner;
+        final Set<UUID> members = new HashSet<>();
+        final int maxMembers;
+
+        Squad(String name, UUID owner, int maxMembers) {
+            this.name = name;
+            this.owner = owner;
+            this.maxMembers = maxMembers;
+        }
+
+        int onlineCount() {
+            int c = 0;
+            for (UUID uuid : members) {
+                Player p = Bukkit.getPlayer(uuid);
+                if (p != null && p.isOnline()) c++;
+            }
+            return c;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,13 @@
+boss:
+  hp_default: 10000
+  armor_default: 50
+  name: "태초의 도깨비"
+inherit:
+  power_key: "dokkaebi.core"
+  buffs:
+    - "speed:1"
+    - "strength:1"
+  announce: true
+squad:
+  max_members: 5
+  friendly_fire: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,20 @@
+name: MythOfFive
+main: com.mythof5.MythPlugin
+version: 0.1.0
+api-version: '1.20'
+commands:
+  myth:
+    description: Myth administrative commands
+    usage: /myth admin <subcommand>
+    permission: myth.admin
+  squad:
+    description: Squad commands
+    usage: /squad <subcommand>
+    permission: myth.user.squad
+permissions:
+  myth.admin:
+    description: Allows use of myth admin commands
+    default: false
+  myth.user.squad:
+    description: Allows use of squad commands
+    default: true


### PR DESCRIPTION
## Summary
- add boss bar display and log spawn/defeat events
- track inheritor power with persistent key and announce inheritance loss
- record squad lifecycle actions to server logs

## Testing
- `mvn -q package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fe91e7608324aed0c533f9a249fe