### PR TITLE
Finalize goblin ritual triggers and command UX

### DIFF
--- a/mythof5/src/main/java/me/j17e4eo/mythof5/balance/BalanceTable.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/balance/BalanceTable.java
@@ -1,0 +1,26 @@
+package me.j17e4eo.mythof5.balance;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Stores balancing targets for quick reference via commands.
+ */
+public class BalanceTable {
+
+    private final Map<String, String> metrics = new LinkedHashMap<>();
+
+    public BalanceTable() {
+        metrics.put("계승자 vs 일반", "승률 70% 이상");
+        metrics.put("계승자 vs 설화 조합팀", "상황에 따라 50% 이하");
+        metrics.put("설화 단독 효과", "소규모 전투 결정적 / 대규모 전투 보조");
+        metrics.put("연대기 기록 정확도", "100% (실시간 검증)");
+    }
+
+    public List<String> format() {
+        return metrics.entrySet().stream()
+                .map(entry -> "• " + entry.getKey() + " : " + entry.getValue())
+                .toList();
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/boss/BossManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/boss/BossManager.java
@@ -2,6 +2,7 @@ package me.j17e4eo.mythof5.boss;
 
 import me.j17e4eo.mythof5.Mythof5;
 import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.inherit.AspectManager;
 import me.j17e4eo.mythof5.inherit.InheritManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -31,6 +32,7 @@ public class BossManager {
 
     private final Mythof5 plugin;
     private final InheritManager inheritManager;
+    private final AspectManager aspectManager;
     private final Messages messages;
     private final Map<Integer, BossInstance> activeBosses = new HashMap<>();
     private final Map<UUID, BossInstance> bossesByEntity = new HashMap<>();
@@ -39,9 +41,10 @@ public class BossManager {
     private final double defaultArmor;
     private final String defaultName;
 
-    public BossManager(Mythof5 plugin, InheritManager inheritManager, Messages messages) {
+    public BossManager(Mythof5 plugin, InheritManager inheritManager, AspectManager aspectManager, Messages messages) {
         this.plugin = plugin;
         this.inheritManager = inheritManager;
+        this.aspectManager = aspectManager;
         this.messages = messages;
         this.defaultHp = plugin.getConfig().getDouble("boss.hp_default", 10000D);
         this.defaultArmor = plugin.getConfig().getDouble("boss.armor_default", 50D);
@@ -121,6 +124,7 @@ public class BossManager {
             plugin.getLogger().info(String.format("[Event:BOSS_DEFEATED] Boss #%d defeated by %s at %s", instance.getId(),
                     killer.getName(), stringifyLocation(location)));
             inheritManager.grantFromBoss(killer, instance.getDisplayName());
+            aspectManager.handleBossDefeat(killer, instance.getDisplayName());
         } else {
             plugin.getLogger().info(String.format("[Event:BOSS_DEFEATED] Boss #%d died without a killer at %s", instance.getId(),
                     stringifyLocation(location)));

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/chronicle/ChronicleEventType.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/chronicle/ChronicleEventType.java
@@ -1,0 +1,15 @@
+package me.j17e4eo.mythof5.chronicle;
+
+/**
+ * Enumerates chronicle event types. Each type corresponds to a default
+ * old-Korean style sentence fragment stored in messages.yml.
+ */
+public enum ChronicleEventType {
+    INHERIT,
+    LOSS,
+    SHARE,
+    SKILL,
+    RELIC_GAIN,
+    RELIC_FUSION,
+    OMEN
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/chronicle/ChronicleManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/chronicle/ChronicleManager.java
@@ -1,0 +1,132 @@
+package me.j17e4eo.mythof5.chronicle;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.config.Messages;
+import org.bukkit.entity.Player;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Stores server chronicles in an old-Korean narrative style.
+ */
+public class ChronicleManager {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm")
+            .withLocale(Locale.KOREA).withZone(ZoneId.systemDefault());
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private final List<ChronicleRecord> records = new ArrayList<>();
+    private File file;
+    private YamlConfiguration config;
+
+    public ChronicleManager(Mythof5 plugin, Messages messages) {
+        this.plugin = plugin;
+        this.messages = messages;
+    }
+
+    public void load() {
+        plugin.getDataFolder().mkdirs();
+        file = new File(plugin.getDataFolder(), "chronicle.yml");
+        if (!file.exists()) {
+            config = new YamlConfiguration();
+            return;
+        }
+        config = YamlConfiguration.loadConfiguration(file);
+        records.clear();
+        List<Map<?, ?>> section = config.getMapList("entries");
+        for (Map<?, ?> raw : section) {
+            try {
+                String typeRaw = Objects.toString(raw.get("type"), null);
+                String timeRaw = Objects.toString(raw.get("time"), null);
+                String text = Objects.toString(raw.get("text"), "");
+                if (typeRaw == null || timeRaw == null) {
+                    continue;
+                }
+                ChronicleEventType type = ChronicleEventType.valueOf(typeRaw);
+                Instant instant = Instant.parse(timeRaw);
+                List<String> witnesses = new ArrayList<>();
+                Object witnessRaw = raw.get("witnesses");
+                if (witnessRaw instanceof List<?> list) {
+                    for (Object entry : list) {
+                        if (entry != null) {
+                            witnesses.add(entry.toString());
+                        }
+                    }
+                }
+                records.add(new ChronicleRecord(type, instant, text, witnesses));
+            } catch (Exception ex) {
+                plugin.getLogger().warning("Failed to load chronicle entry: " + ex.getMessage());
+            }
+        }
+    }
+
+    public void save() {
+        if (config == null) {
+            config = new YamlConfiguration();
+        }
+        List<Map<String, Object>> serialized = new ArrayList<>();
+        for (ChronicleRecord record : records) {
+            serialized.add(Map.of(
+                    "type", record.type().name(),
+                    "time", record.timestamp().toString(),
+                    "text", record.text(),
+                    "witnesses", record.witnesses()
+            ));
+        }
+        config.set("entries", serialized);
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to save chronicle: " + e.getMessage());
+        }
+    }
+
+    public synchronized void logEvent(ChronicleEventType type, String text, Collection<Player> witnesses) {
+        if (text == null || text.isBlank()) {
+            text = messages.format("chronicle.default." + type.name().toLowerCase(Locale.ROOT));
+        }
+        List<String> witnessNames = new ArrayList<>();
+        if (witnesses != null) {
+            for (Player player : witnesses) {
+                witnessNames.add(player.getName());
+                player.addScoreboardTag("myth_witness");
+            }
+        }
+        ChronicleRecord record = new ChronicleRecord(type, Instant.now(), text, witnessNames);
+        records.add(record);
+        plugin.getLogger().info("[Chronicle] " + text);
+        save();
+    }
+
+    public List<String> formatRecent(int limit) {
+        if (records.isEmpty()) {
+            return List.of(messages.format("chronicle.empty"));
+        }
+        int start = Math.max(0, records.size() - limit);
+        List<String> formatted = new ArrayList<>();
+        for (int i = records.size() - 1; i >= start; i--) {
+            ChronicleRecord record = records.get(i);
+            formatted.add(FORMATTER.format(record.timestamp()) + " · " + record.text());
+        }
+        return formatted;
+    }
+
+    public List<ChronicleRecord> getRecords() {
+        return Collections.unmodifiableList(records);
+    }
+
+    public record ChronicleRecord(ChronicleEventType type, Instant timestamp, String text, List<String> witnesses) {}
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/command/GoblinCommand.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/command/GoblinCommand.java
@@ -1,0 +1,305 @@
+package me.j17e4eo.mythof5.command;
+
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.inherit.AspectManager;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinAspect;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinSkill;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinSkillCategory;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class GoblinCommand implements CommandExecutor, TabCompleter {
+
+    private final AspectManager aspectManager;
+    private final Messages messages;
+
+    public GoblinCommand(AspectManager aspectManager, Messages messages) {
+        this.aspectManager = aspectManager;
+        this.messages = messages;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sendUsage(sender, label);
+            return true;
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        switch (sub) {
+            case "help" -> {
+                sendUsage(sender, label);
+                return true;
+            }
+            case "skill" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                if (args.length < 2) {
+                    showSkills(sender, args);
+                    return true;
+                }
+                aspectManager.useSkill(player, args[1]);
+                return true;
+            }
+            case "skills" -> {
+                showSkills(sender, args);
+                return true;
+            }
+            case "info" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                showInfo(player);
+                return true;
+            }
+            case "progress" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                showProgress(player);
+                return true;
+            }
+            case "share" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                if (args.length < 3) {
+                    sendUsage(sender, label);
+                    return true;
+                }
+                handleShare(player, args[1], args[2], true);
+                return true;
+            }
+            case "reclaim" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                if (args.length < 3) {
+                    sendUsage(sender, label);
+                    return true;
+                }
+                handleShare(player, args[1], args[2], false);
+                return true;
+            }
+            case "contract" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                aspectManager.attemptMischiefContract(player);
+                return true;
+            }
+            case "forge" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                aspectManager.attemptForgeRitual(player);
+                return true;
+            }
+            case "list" -> {
+                listAspects(sender);
+                return true;
+            }
+            default -> {
+                sendUsage(sender, label);
+                return true;
+            }
+        }
+    }
+
+    private void sendUsage(CommandSender sender, String label) {
+        for (String line : messages.formatList("goblin.usage", Map.of("label", "/" + label))) {
+            sender.sendMessage(line);
+        }
+    }
+
+    private void showSkills(CommandSender sender, String[] args) {
+        List<GoblinAspect> aspects = new ArrayList<>();
+        if (args.length >= 2) {
+            GoblinAspect aspect = GoblinAspect.fromKey(args[1]);
+            if (aspect == null) {
+                sender.sendMessage(messages.format("goblin.aspect.unknown"));
+                return;
+            }
+            aspects.add(aspect);
+        } else if (sender instanceof Player player) {
+            Set<GoblinAspect> owned = aspectManager.getAspects(player.getUniqueId());
+            if (owned.isEmpty()) {
+                aspects.addAll(List.of(GoblinAspect.values()));
+            } else {
+                aspects.addAll(owned);
+            }
+        } else {
+            aspects.addAll(List.of(GoblinAspect.values()));
+        }
+        sender.sendMessage(messages.format("goblin.skills.header"));
+        for (GoblinAspect aspect : aspects) {
+            sender.sendMessage(messages.format("goblin.skills.aspect", Map.of(
+                    "aspect", aspect.getDisplayName(),
+                    "key", aspect.getKey()
+            )));
+            for (GoblinSkill skill : aspect.getSkills()) {
+                String key;
+                switch (skill.getCategory()) {
+                    case PASSIVE -> key = "goblin.skills.entry.passive";
+                    case UTILITY -> key = "goblin.skills.entry.utility";
+                    default -> key = "goblin.skills.entry.active";
+                }
+                sender.sendMessage(messages.format(key, Map.of(
+                        "code", skill.getKey(),
+                        "name", skill.getDisplayName(),
+                        "cooldown", skill.getCategory() == GoblinSkillCategory.PASSIVE
+                                ? "-"
+                                : String.valueOf(skill.getBaseCooldownSeconds()),
+                        "desc", skill.getDescription()
+                )));
+            }
+        }
+    }
+
+    private void showInfo(Player player) {
+        Set<GoblinAspect> aspects = aspectManager.getAspects(player.getUniqueId());
+        if (aspects.isEmpty()) {
+            player.sendMessage(messages.format("goblin.info.none"));
+            return;
+        }
+        player.sendMessage(messages.format("goblin.info.header"));
+        for (GoblinAspect aspect : aspects) {
+            player.sendMessage(messages.format("goblin.info.aspect", Map.of(
+                    "aspect", aspect.getDisplayName(),
+                    "personality", aspect.getPersonality(),
+                    "acquire", aspect.getAcquisition()
+            )));
+            for (GoblinSkill skill : aspect.getSkills()) {
+                String key = skill.getCategory() == GoblinSkillCategory.PASSIVE
+                        ? "goblin.info.skill.passive"
+                        : "goblin.info.skill.active";
+                player.sendMessage(messages.format(key, Map.of(
+                        "name", skill.getDisplayName(),
+                        "code", skill.getKey(),
+                        "desc", skill.getDescription()
+                )));
+            }
+        }
+    }
+
+    private void showProgress(Player player) {
+        for (String line : aspectManager.describeProgress(player)) {
+            player.sendMessage(line);
+        }
+    }
+
+    private void handleShare(Player player, String aspectToken, String targetName, boolean share) {
+        GoblinAspect aspect = GoblinAspect.fromKey(aspectToken);
+        if (aspect == null) {
+            player.sendMessage(messages.format("goblin.aspect.unknown"));
+            return;
+        }
+        if (!aspectManager.isInheritor(aspect, player.getUniqueId())) {
+            player.sendMessage(messages.format("goblin.aspect.not_holder"));
+            return;
+        }
+        Player target = Bukkit.getPlayerExact(targetName);
+        if (target == null) {
+            player.sendMessage(messages.format("commands.common.player_not_online"));
+            return;
+        }
+        if (share) {
+            if (aspectManager.sharePower(aspect, target)) {
+                player.sendMessage(messages.format("goblin.share.success", Map.of(
+                        "player", target.getName(),
+                        "aspect", aspect.getDisplayName()
+                )));
+                target.sendMessage(messages.format("goblin.share.received", Map.of(
+                        "aspect", aspect.getDisplayName(),
+                        "player", player.getName()
+                )));
+            } else {
+                player.sendMessage(messages.format("goblin.share.duplicate"));
+            }
+        } else {
+            if (aspectManager.reclaimPower(aspect, target)) {
+                player.sendMessage(messages.format("goblin.reclaim.success", Map.of(
+                        "player", target.getName(),
+                        "aspect", aspect.getDisplayName()
+                )));
+                target.sendMessage(messages.format("goblin.reclaim.notice", Map.of(
+                        "aspect", aspect.getDisplayName()
+                )));
+            } else {
+                player.sendMessage(messages.format("goblin.reclaim.missing"));
+            }
+        }
+    }
+
+    private void listAspects(CommandSender sender) {
+        for (GoblinAspect aspect : GoblinAspect.values()) {
+            String inheritor = aspectManager.getInheritorName(aspect);
+            if (inheritor == null) {
+                inheritor = messages.format("goblin.list.none");
+            }
+            sender.sendMessage(messages.format("goblin.list.entry", Map.of(
+                    "aspect", aspect.getDisplayName(),
+                    "holder", inheritor
+            )));
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+        if (args.length == 1) {
+            completions.addAll(List.of("help", "info", "skill", "skills", "progress", "share", "reclaim", "contract", "forge", "list"));
+        } else if (args.length == 2) {
+            switch (args[0].toLowerCase(Locale.ROOT)) {
+                case "skill" -> {
+                    if (sender instanceof Player player) {
+                        Set<String> keys = new HashSet<>();
+                        for (GoblinAspect aspect : aspectManager.getAspects(player.getUniqueId())) {
+                            for (GoblinSkill skill : aspect.getSkills()) {
+                                if (skill.getCategory() != GoblinSkillCategory.PASSIVE) {
+                                    keys.add(skill.getKey());
+                                }
+                            }
+                        }
+                        completions.addAll(keys);
+                    }
+                }
+                case "skills" -> {
+                    for (GoblinAspect aspect : GoblinAspect.values()) {
+                        completions.add(aspect.getKey());
+                    }
+                }
+                case "share", "reclaim" -> {
+                    for (GoblinAspect aspect : GoblinAspect.values()) {
+                        completions.add(aspect.getKey());
+                    }
+                }
+            }
+        } else if (args.length == 3 && (args[0].equalsIgnoreCase("share") || args[0].equalsIgnoreCase("reclaim"))) {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                completions.add(player.getName());
+            }
+        }
+        String current = args[args.length - 1].toLowerCase(Locale.ROOT);
+        return completions.stream().filter(entry -> entry.toLowerCase(Locale.ROOT).startsWith(current)).toList();
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/command/RelicCommand.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/command/RelicCommand.java
@@ -1,0 +1,96 @@
+package me.j17e4eo.mythof5.command;
+
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.relic.RelicFusion;
+import me.j17e4eo.mythof5.relic.RelicManager;
+import me.j17e4eo.mythof5.relic.RelicType;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class RelicCommand implements CommandExecutor, TabCompleter {
+
+    private final RelicManager relicManager;
+    private final Messages messages;
+
+    public RelicCommand(RelicManager relicManager, Messages messages) {
+        this.relicManager = relicManager;
+        this.messages = messages;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sendUsage(sender, label);
+            return true;
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        switch (sub) {
+            case "list" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                showRelics(player);
+                return true;
+            }
+            case "fusions" -> {
+                showFusions(sender);
+                return true;
+            }
+            default -> {
+                sendUsage(sender, label);
+                return true;
+            }
+        }
+    }
+
+    private void sendUsage(CommandSender sender, String label) {
+        for (String line : messages.formatList("relic.usage", Map.of("label", "/" + label))) {
+            sender.sendMessage(line);
+        }
+    }
+
+    private void showRelics(Player player) {
+        for (String line : relicManager.describeRelics(player.getUniqueId())) {
+            player.sendMessage(line);
+        }
+    }
+
+    private void showFusions(CommandSender sender) {
+        List<RelicFusion> fusions = relicManager.getFusions();
+        if (fusions.isEmpty()) {
+            sender.sendMessage(messages.format("relic.fusion.none"));
+            return;
+        }
+        sender.sendMessage(messages.format("relic.fusion.header"));
+        for (RelicFusion fusion : fusions) {
+            String ingredients = fusion.getIngredients().stream()
+                    .map(RelicType::getDisplayName)
+                    .reduce((a, b) -> a + " + " + b)
+                    .orElse("");
+            sender.sendMessage(messages.format("relic.fusion.entry", Map.of(
+                    "result", fusion.getResult().getDisplayName(),
+                    "ingredients", ingredients,
+                    "desc", fusion.getDescription()
+            )));
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+        if (args.length == 1) {
+            completions.addAll(List.of("list", "fusions"));
+        }
+        String current = args[args.length - 1].toLowerCase(Locale.ROOT);
+        return completions.stream().filter(entry -> entry.toLowerCase(Locale.ROOT).startsWith(current)).toList();
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/AspectManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/AspectManager.java
@@ -1,0 +1,1367 @@
+package me.j17e4eo.mythof5.inherit;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.chronicle.ChronicleEventType;
+import me.j17e4eo.mythof5.chronicle.ChronicleManager;
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinAspect;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinSkill;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinSkillCategory;
+import me.j17e4eo.mythof5.omens.OmenManager;
+import me.j17e4eo.mythof5.omens.OmenStage;
+import me.j17e4eo.mythof5.relic.RelicManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Campfire;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Handles the five goblin aspects including inheritance, sharing and skill
+ * execution.
+ */
+public class AspectManager {
+
+    private static final double HEALTH_PENALTY_PER_SHARE = 2.0D;
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private final ChronicleManager chronicleManager;
+    private final RelicManager relicManager;
+    private final OmenManager omenManager;
+    private final Map<GoblinAspect, AspectProfile> profiles = new EnumMap<>(GoblinAspect.class);
+    private final Map<GoblinAspect, NamespacedKey> healthModifierKeys = new EnumMap<>(GoblinAspect.class);
+    private final Map<UUID, Map<String, Long>> cooldowns = new ConcurrentHashMap<>();
+    private final Map<UUID, BukkitTask> scentTasks = new HashMap<>();
+    private final NamespacedKey legendaryWeaponKey;
+    private final Set<String> powerBossKeywords;
+    private final Material speedTraceEyeItem;
+    private final Material speedTraceHornItem;
+    private final Map<UUID, EnumSet<TraceToken>> speedProgress = new HashMap<>();
+    private final Set<Material> contractMaterials;
+    private final List<String> contractKeywords;
+    private final Set<Material> flameRitualBlocks;
+    private final Material flameCatalyst;
+    private final Material forgeCatalyst;
+    private final Material forgeFuel;
+    private final Set<Material> forgeStations;
+    private final int forgeRadius;
+    private final Map<UUID, Double> originalMaxHealth = new HashMap<>();
+    private final Map<UUID, Set<GoblinAspect>> activeInheritorAspects = new HashMap<>();
+    private final Map<UUID, Double> pendingMaxHealthRestores = new HashMap<>();
+    private File dataFile;
+    private YamlConfiguration dataConfig;
+
+    public AspectManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager,
+                         RelicManager relicManager, OmenManager omenManager) {
+        this.plugin = plugin;
+        this.messages = messages;
+        this.chronicleManager = chronicleManager;
+        this.relicManager = relicManager;
+        this.omenManager = omenManager;
+        this.legendaryWeaponKey = new NamespacedKey(plugin, "legendary_summon");
+        FileConfiguration config = plugin.getConfig();
+        powerBossKeywords = new HashSet<>();
+        for (String keyword : config.getStringList("goblin.triggers.power.boss_keywords")) {
+            if (keyword != null && !keyword.isBlank()) {
+                powerBossKeywords.add(keyword.toLowerCase(Locale.ROOT));
+            }
+        }
+        if (powerBossKeywords.isEmpty()) {
+            powerBossKeywords.add("태초의 도깨비".toLowerCase(Locale.ROOT));
+        }
+
+        List<String> speedItems = config.getStringList("goblin.triggers.speed.trace_items");
+        speedTraceEyeItem = resolveMaterial(speedItems, 0, Material.SNOWBALL);
+        speedTraceHornItem = resolveMaterial(speedItems, 1, Material.GOAT_HORN);
+
+        contractMaterials = resolveMaterialSet(config.getStringList("goblin.triggers.mischief.contract_items"),
+                EnumSet.of(Material.WRITTEN_BOOK, Material.WRITABLE_BOOK));
+        contractKeywords = buildKeywordList(config.getStringList("goblin.triggers.mischief.contract_keywords"),
+                List.of("계약"));
+
+        flameRitualBlocks = resolveMaterialSet(config.getStringList("goblin.triggers.flame.ritual_blocks"),
+                EnumSet.of(Material.CAMPFIRE, Material.SOUL_CAMPFIRE));
+        flameCatalyst = resolveMaterial(config.getString("goblin.triggers.flame.catalyst"), Material.BLAZE_POWDER);
+
+        forgeCatalyst = resolveMaterial(config.getString("goblin.triggers.forge.catalyst"), Material.NETHERITE_INGOT);
+        forgeFuel = resolveMaterial(config.getString("goblin.triggers.forge.fuel"), Material.BLAZE_ROD);
+        forgeStations = resolveMaterialSet(config.getStringList("goblin.triggers.forge.station_blocks"),
+                EnumSet.of(Material.SMITHING_TABLE, Material.ANVIL));
+        forgeRadius = Math.max(1, config.getInt("goblin.triggers.forge.radius", 4));
+        for (GoblinAspect aspect : GoblinAspect.values()) {
+            profiles.put(aspect, new AspectProfile());
+            healthModifierKeys.put(aspect, new NamespacedKey(plugin, "aspect_penalty_" + aspect.getKey()));
+        }
+    }
+
+    public void load() {
+        plugin.getDataFolder().mkdirs();
+        dataFile = new File(plugin.getDataFolder(), "goblins.yml");
+        if (!dataFile.exists()) {
+            dataConfig = new YamlConfiguration();
+            return;
+        }
+        dataConfig = YamlConfiguration.loadConfiguration(dataFile);
+        for (GoblinAspect aspect : GoblinAspect.values()) {
+            AspectProfile profile = profiles.get(aspect);
+            String base = "aspects." + aspect.getKey();
+            String uuid = dataConfig.getString(base + ".inheritor.uuid");
+            profile.shared.clear();
+            if (uuid != null && !uuid.isEmpty()) {
+                try {
+                    profile.inheritor = UUID.fromString(uuid);
+                    profile.name = dataConfig.getString(base + ".inheritor.name");
+                } catch (IllegalArgumentException ignored) {
+                    plugin.getLogger().warning("Invalid UUID for aspect " + aspect.getKey());
+                }
+            }
+            List<String> sharedList = dataConfig.getStringList(base + ".shared");
+            for (String shared : sharedList) {
+                try {
+                    profile.shared.add(UUID.fromString(shared));
+                } catch (IllegalArgumentException ignored) {
+                    plugin.getLogger().warning("Invalid shared UUID for aspect " + aspect.getKey() + ": " + shared);
+                }
+            }
+        }
+        speedProgress.clear();
+        ConfigurationSection speedSection = dataConfig.getConfigurationSection("progress.speed");
+        if (speedSection != null) {
+            for (String key : speedSection.getKeys(false)) {
+                try {
+                    UUID uuid = UUID.fromString(key);
+                    List<String> tokens = speedSection.getStringList(key);
+                    EnumSet<TraceToken> set = EnumSet.noneOf(TraceToken.class);
+                    for (String token : tokens) {
+                        TraceToken traceToken = TraceToken.fromKey(token);
+                        if (traceToken != null) {
+                            set.add(traceToken);
+                        }
+                    }
+                    if (!set.isEmpty()) {
+                        speedProgress.put(uuid, set);
+                    }
+                } catch (IllegalArgumentException ex) {
+                    plugin.getLogger().warning("Invalid UUID in goblin trace progress: " + key);
+                }
+            }
+        }
+    }
+
+    public void save() {
+        if (dataConfig == null) {
+            dataConfig = new YamlConfiguration();
+        }
+        for (GoblinAspect aspect : GoblinAspect.values()) {
+            AspectProfile profile = profiles.get(aspect);
+            String base = "aspects." + aspect.getKey();
+            if (profile.inheritor == null) {
+                dataConfig.set(base, null);
+                continue;
+            }
+            dataConfig.set(base + ".inheritor.uuid", profile.inheritor.toString());
+            dataConfig.set(base + ".inheritor.name", profile.name);
+            List<String> shared = new ArrayList<>(profile.shared.size());
+            for (UUID uuid : profile.shared) {
+                shared.add(uuid.toString());
+            }
+            dataConfig.set(base + ".shared", shared);
+        }
+        dataConfig.set("progress.speed", null);
+        if (!speedProgress.isEmpty()) {
+            for (Map.Entry<UUID, EnumSet<TraceToken>> entry : speedProgress.entrySet()) {
+                List<String> values = new ArrayList<>();
+                for (TraceToken token : entry.getValue()) {
+                    values.add(token.name());
+                }
+                dataConfig.set("progress.speed." + entry.getKey(), values);
+            }
+        }
+        try {
+            dataConfig.save(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to save goblin aspect data: " + e.getMessage());
+        }
+    }
+
+    public void handlePlayerJoin(Player player) {
+        UUID uuid = player.getUniqueId();
+        Double pending = pendingMaxHealthRestores.remove(uuid);
+        if (pending != null) {
+            AttributeInstance attribute = player.getAttribute(Attribute.MAX_HEALTH);
+            if (attribute != null) {
+                attribute.setBaseValue(pending);
+                if (player.getHealth() > pending) {
+                    player.setHealth(pending);
+                }
+            }
+        }
+        for (GoblinAspect aspect : GoblinAspect.values()) {
+            AspectProfile profile = profiles.get(aspect);
+            if (profile.isInheritor(uuid)) {
+                applyInheritorHealth(aspect, player);
+                applyPassive(aspect, player, true);
+                applySharedEffects(aspect, player);
+            } else if (profile.shared.contains(uuid)) {
+                applyPassive(aspect, player, false);
+            }
+        }
+        cleanupLegendaryWeapons(player.getInventory());
+    }
+
+    public void handlePlayerQuit(Player player) {
+        cancelScentTask(player.getUniqueId());
+    }
+
+    public void handleDeath(PlayerDeathEvent event) {
+        Player victim = event.getEntity();
+        Player killer = victim.getKiller();
+        for (GoblinAspect aspect : GoblinAspect.values()) {
+            AspectProfile profile = profiles.get(aspect);
+            if (!profile.isInheritor(victim.getUniqueId())) {
+                continue;
+            }
+            if (killer != null && !killer.getUniqueId().equals(victim.getUniqueId())) {
+                setInheritor(aspect, killer, true, messages.format("chronicle.inherit.transfer", Map.of(
+                        "killer", killer.getName(),
+                        "victim", victim.getName(),
+                        "aspect", aspect.getDisplayName()
+                )));
+            } else {
+                clearInheritor(aspect, true, victim.getName());
+            }
+        }
+    }
+
+    public void handleBossDefeat(Player killer, String bossName) {
+        if (killer == null) {
+            return;
+        }
+        AspectProfile powerProfile = profiles.get(GoblinAspect.POWER);
+        if (powerProfile.inheritor == null && bossName != null) {
+            String normalized = bossName.toLowerCase(Locale.ROOT);
+            boolean matches = false;
+            for (String keyword : powerBossKeywords) {
+                if (normalized.contains(keyword)) {
+                    matches = true;
+                    break;
+                }
+            }
+            if (!matches) {
+                return;
+            }
+            setInheritor(GoblinAspect.POWER, killer, true, messages.format("chronicle.inherit.obtain", Map.of(
+                    "player", killer.getName(),
+                    "aspect", GoblinAspect.POWER.getDisplayName(),
+                    "method", "현신 격파"
+            )));
+        }
+    }
+
+    public void handleTracePickup(Player player, ItemStack itemStack) {
+        if (itemStack == null || itemStack.getType().isAir()) {
+            return;
+        }
+        AspectProfile profile = profiles.get(GoblinAspect.SPEED);
+        UUID uuid = player.getUniqueId();
+        if (profile.isInheritor(uuid)) {
+            return;
+        }
+        if (profile.inheritor != null && !profile.inheritor.equals(uuid)) {
+            return;
+        }
+        TraceToken token = traceTokenFromMaterial(itemStack.getType());
+        if (token == null) {
+            return;
+        }
+        EnumSet<TraceToken> progress = speedProgress.computeIfAbsent(uuid, key -> EnumSet.noneOf(TraceToken.class));
+        if (!progress.add(token)) {
+            return;
+        }
+        save();
+        switch (token) {
+            case EYE -> player.sendMessage(messages.format("goblin.ritual.speed.collect.eye", Map.of(
+                    "item", describeMaterial(speedTraceEyeItem)
+            )));
+            case HORN -> player.sendMessage(messages.format("goblin.ritual.speed.collect.horn", Map.of(
+                    "item", describeMaterial(speedTraceHornItem)
+            )));
+        }
+        if (progress.containsAll(EnumSet.allOf(TraceToken.class))) {
+            player.sendMessage(messages.format("goblin.ritual.speed.complete"));
+            setInheritor(GoblinAspect.SPEED, player, true, messages.format("chronicle.inherit.obtain", Map.of(
+                    "player", player.getName(),
+                    "aspect", GoblinAspect.SPEED.getDisplayName(),
+                    "method", "흔적 수집"
+            )));
+        } else {
+            player.sendMessage(messages.format("goblin.ritual.speed.progress", Map.of(
+                    "current", String.valueOf(progress.size()),
+                    "total", String.valueOf(EnumSet.allOf(TraceToken.class).size())
+            )));
+        }
+    }
+
+    public void attemptMischiefContract(Player player) {
+        AspectProfile profile = profiles.get(GoblinAspect.MISCHIEF);
+        UUID uuid = player.getUniqueId();
+        if (profile.isInheritor(uuid)) {
+            player.sendMessage(messages.format("goblin.contract.already_holder"));
+            return;
+        }
+        if (profile.inheritor != null) {
+            String holder = profile.name != null ? profile.name : messages.format("goblin.list.none");
+            player.sendMessage(messages.format("goblin.contract.taken", Map.of("player", holder)));
+            return;
+        }
+        ItemStack held = player.getInventory().getItemInMainHand();
+        if (held == null || held.getType().isAir() || !contractMaterials.contains(held.getType())) {
+            player.sendMessage(messages.format("goblin.contract.require_item", Map.of(
+                    "items", describeMaterials(contractMaterials)
+            )));
+            return;
+        }
+        if (!matchesContractKeywords(held)) {
+            player.sendMessage(messages.format("goblin.contract.require_keyword", Map.of(
+                    "keywords", String.join(", ", contractKeywords)
+            )));
+            return;
+        }
+        consumeMainHand(player);
+        player.getWorld().playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0F, 0.6F);
+        player.getWorld().spawnParticle(Particle.ENCHANT, player.getLocation().add(0, 1, 0), 40, 0.4, 0.6, 0.4, 0.05);
+        setInheritor(GoblinAspect.MISCHIEF, player, true, messages.format("chronicle.inherit.obtain", Map.of(
+                "player", player.getName(),
+                "aspect", GoblinAspect.MISCHIEF.getDisplayName(),
+                "method", "계약 성립"
+        )));
+        player.sendMessage(messages.format("goblin.contract.success", Map.of(
+                "aspect", GoblinAspect.MISCHIEF.getDisplayName()
+        )));
+    }
+
+    public void handleEmberRitual(Player player, Block block) {
+        if (block == null || !flameRitualBlocks.contains(block.getType())) {
+            return;
+        }
+        AspectProfile profile = profiles.get(GoblinAspect.FLAME);
+        UUID uuid = player.getUniqueId();
+        if (profile.isInheritor(uuid)) {
+            return;
+        }
+        if (profile.inheritor != null && !profile.inheritor.equals(uuid)) {
+            return;
+        }
+        ItemStack held = player.getInventory().getItemInMainHand();
+        if (held == null || held.getType() != flameCatalyst) {
+            player.sendMessage(messages.format("goblin.ritual.flame.require_item", Map.of(
+                    "item", describeMaterial(flameCatalyst)
+            )));
+            return;
+        }
+        igniteCampfire(block);
+        consumeMainHand(player);
+        player.getWorld().spawnParticle(Particle.FLAME, block.getLocation().add(0.5, 1.2, 0.5), 80, 0.4, 0.5, 0.4, 0.02);
+        player.getWorld().playSound(block.getLocation(), Sound.ITEM_FIRECHARGE_USE, 0.9F, 1.1F);
+        setInheritor(GoblinAspect.FLAME, player, true, messages.format("chronicle.inherit.obtain", Map.of(
+                "player", player.getName(),
+                "aspect", GoblinAspect.FLAME.getDisplayName(),
+                "method", "불씨 의례"
+        )));
+        player.sendMessage(messages.format("goblin.ritual.flame.success"));
+    }
+
+    public void attemptForgeRitual(Player player) {
+        AspectProfile profile = profiles.get(GoblinAspect.FORGE);
+        UUID uuid = player.getUniqueId();
+        if (profile.isInheritor(uuid)) {
+            player.sendMessage(messages.format("goblin.ritual.forge.already"));
+            return;
+        }
+        if (profile.inheritor != null && !profile.inheritor.equals(uuid)) {
+            player.sendMessage(messages.format("goblin.ritual.forge.taken", Map.of(
+                    "player", profile.name != null ? profile.name : messages.format("goblin.list.none")
+            )));
+            return;
+        }
+        PlayerInventory inventory = player.getInventory();
+        if (!inventory.contains(forgeCatalyst)) {
+            player.sendMessage(messages.format("goblin.ritual.forge.require_catalyst", Map.of(
+                    "item", describeMaterial(forgeCatalyst)
+            )));
+            return;
+        }
+        if (!inventory.contains(forgeFuel)) {
+            player.sendMessage(messages.format("goblin.ritual.forge.require_fuel", Map.of(
+                    "item", describeMaterial(forgeFuel)
+            )));
+            return;
+        }
+        if (!isNearForgeStation(player)) {
+            player.sendMessage(messages.format("goblin.ritual.forge.require_station", Map.of(
+                    "blocks", describeMaterials(forgeStations)
+            )));
+            return;
+        }
+        removeFromInventory(inventory, forgeCatalyst);
+        removeFromInventory(inventory, forgeFuel);
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_ANVIL_USE, 1.0F, 0.8F);
+        player.getWorld().spawnParticle(Particle.CRIT, player.getLocation().add(0, 1, 0), 60, 0.5, 0.7, 0.5, 0.1);
+        setInheritor(GoblinAspect.FORGE, player, true, messages.format("chronicle.inherit.obtain", Map.of(
+                "player", player.getName(),
+                "aspect", GoblinAspect.FORGE.getDisplayName(),
+                "method", "특수 제작 의식"
+        )));
+        player.sendMessage(messages.format("goblin.ritual.forge.success"));
+    }
+
+    public List<String> describeProgress(Player player) {
+        List<String> lines = new ArrayList<>();
+        lines.add(messages.format("goblin.progress.header"));
+        lines.add(describePowerProgress(player));
+        lines.add(describeSpeedProgress(player));
+        lines.add(describeMischiefProgress(player));
+        lines.add(describeFlameProgress(player));
+        lines.add(describeForgeProgress(player));
+        return lines;
+    }
+
+    public void setInheritor(GoblinAspect aspect, Player player, boolean announce, String chronicleText) {
+        AspectProfile profile = profiles.get(aspect);
+        if (profile.inheritor != null && profile.inheritor.equals(player.getUniqueId())) {
+            profile.name = player.getName();
+            applyPassive(aspect, player, true);
+            return;
+        }
+        Player previousPlayer = profile.inheritor != null ? Bukkit.getPlayer(profile.inheritor) : null;
+        if (previousPlayer != null && previousPlayer.isOnline()) {
+            removePassive(aspect, previousPlayer, true);
+        }
+        profile.inheritor = player.getUniqueId();
+        profile.name = player.getName();
+        applyInheritorHealth(aspect, player);
+        applyPassive(aspect, player, true);
+        applySharedEffects(aspect, player);
+        updateHealthPenalty(aspect);
+        if (aspect == GoblinAspect.SPEED) {
+            speedProgress.remove(player.getUniqueId());
+        }
+        if (announce) {
+            broadcast(messages.format("goblin.inherit.broadcast", Map.of(
+                    "player", player.getName(),
+                    "aspect", aspect.getDisplayName()
+            )));
+        }
+        if (omenManager != null) {
+            omenManager.trigger(OmenStage.STARSHIFT, aspect.getDisplayName() + " 계승");
+        }
+        if (chronicleText != null) {
+            chronicleManager.logEvent(ChronicleEventType.INHERIT, chronicleText, List.of(player));
+        }
+        save();
+    }
+
+    public void clearInheritor(GoblinAspect aspect, boolean announce, String targetName) {
+        AspectProfile profile = profiles.get(aspect);
+        UUID previous = profile.inheritor;
+        profile.inheritor = null;
+        profile.name = null;
+        if (previous != null) {
+            Player prevPlayer = Bukkit.getPlayer(previous);
+            if (prevPlayer != null) {
+                removePassive(aspect, prevPlayer, true);
+            }
+            removeInheritorHealth(aspect, previous, prevPlayer);
+        }
+        for (UUID shared : new HashSet<>(profile.shared)) {
+            Player target = Bukkit.getPlayer(shared);
+            if (target != null) {
+                removePassive(aspect, target, false);
+            }
+        }
+        profile.shared.clear();
+        updateHealthPenalty(aspect);
+        save();
+        if (announce && targetName != null) {
+            broadcast(messages.format("goblin.inherit.loss", Map.of(
+                    "player", targetName,
+                    "aspect", aspect.getDisplayName()
+            )));
+            chronicleManager.logEvent(ChronicleEventType.LOSS,
+                    messages.format("chronicle.inherit.loss", Map.of(
+                            "player", targetName,
+                            "aspect", aspect.getDisplayName()
+                    )), Collections.emptyList());
+        }
+    }
+
+    public boolean sharePower(GoblinAspect aspect, Player target) {
+        AspectProfile profile = profiles.get(aspect);
+        if (profile.inheritor == null) {
+            return false;
+        }
+        if (profile.shared.contains(target.getUniqueId())) {
+            return true;
+        }
+        profile.shared.add(target.getUniqueId());
+        applyPassive(aspect, target, false);
+        updateHealthPenalty(aspect);
+        save();
+        chronicleManager.logEvent(ChronicleEventType.SHARE,
+                messages.format("chronicle.inherit.share", Map.of(
+                        "player", getInheritorName(aspect),
+                        "target", target.getName(),
+                        "aspect", aspect.getDisplayName()
+                )), List.of(target));
+        return true;
+    }
+
+    public boolean reclaimPower(GoblinAspect aspect, Player target) {
+        AspectProfile profile = profiles.get(aspect);
+        if (!profile.shared.remove(target.getUniqueId())) {
+            return false;
+        }
+        removePassive(aspect, target, false);
+        updateHealthPenalty(aspect);
+        save();
+        return true;
+    }
+
+    public boolean useSkill(Player player, String key) {
+        key = key.toLowerCase(Locale.ROOT);
+        boolean used = false;
+        for (GoblinAspect aspect : GoblinAspect.values()) {
+            AspectProfile profile = profiles.get(aspect);
+            boolean inheritor = profile.isInheritor(player.getUniqueId());
+            boolean shared = profile.shared.contains(player.getUniqueId());
+            if (!inheritor && !shared) {
+                continue;
+            }
+            for (GoblinSkill skill : aspect.getSkills()) {
+                if (!skill.getKey().equals(key)) {
+                    continue;
+                }
+                if (skill.getCategory() == GoblinSkillCategory.PASSIVE) {
+                    player.sendMessage(messages.format("goblin.skill.passive"));
+                    return true;
+                }
+                int cooldown = skill.getCooldownSeconds(inheritor);
+                if (!checkCooldown(player.getUniqueId(), aspect, skill, cooldown)) {
+                    long remaining = getRemainingCooldown(player.getUniqueId(), aspect, skill);
+                    player.sendMessage(messages.format("goblin.skill.cooldown", Map.of(
+                            "time", formatSeconds(remaining)
+                    )));
+                    return true;
+                }
+                executeSkill(aspect, skill, player, inheritor);
+                registerCooldown(player.getUniqueId(), aspect, skill, cooldown);
+                chronicleManager.logEvent(ChronicleEventType.SKILL,
+                        messages.format("chronicle.skill.use", Map.of(
+                                "player", player.getName(),
+                                "skill", skill.getDisplayName(),
+                                "aspect", aspect.getDisplayName()
+                        )), List.of(player));
+                used = true;
+                break;
+            }
+        }
+        if (!used) {
+            player.sendMessage(messages.format("goblin.skill.unknown"));
+        }
+        return used;
+    }
+
+    public Set<GoblinAspect> getAspects(UUID uuid) {
+        Set<GoblinAspect> aspects = new HashSet<>();
+        for (Map.Entry<GoblinAspect, AspectProfile> entry : profiles.entrySet()) {
+            if (entry.getValue().isInheritor(uuid) || entry.getValue().shared.contains(uuid)) {
+                aspects.add(entry.getKey());
+            }
+        }
+        return aspects;
+    }
+
+    public String getInheritorName(GoblinAspect aspect) {
+        AspectProfile profile = profiles.get(aspect);
+        return profile.name;
+    }
+
+    public Set<UUID> getSharedMembers(GoblinAspect aspect) {
+        return Collections.unmodifiableSet(profiles.get(aspect).shared);
+    }
+
+    public boolean isInheritor(GoblinAspect aspect, UUID uuid) {
+        return profiles.get(aspect).isInheritor(uuid);
+    }
+
+    public boolean isShared(GoblinAspect aspect, UUID uuid) {
+        return profiles.get(aspect).shared.contains(uuid);
+    }
+
+    public Optional<GoblinSkill> findSkill(GoblinAspect aspect, String key) {
+        String normalized = key.toLowerCase(Locale.ROOT);
+        return aspect.getSkills().stream().filter(skill -> skill.getKey().equals(normalized)).findFirst();
+    }
+
+    public void markWitness(Player player) {
+        player.addScoreboardTag("myth_witness");
+    }
+
+    private void executeSkill(GoblinAspect aspect, GoblinSkill skill, Player player, boolean inheritor) {
+        double effectiveness = inheritor ? 1.0D : skill.getSharedEffectiveness();
+        switch (skill.getKey()) {
+            case "rush_strike" -> performRushStrike(player, effectiveness);
+            case "pursuit_mark" -> performPursuitMark(player, effectiveness);
+            case "vision_twist" -> performVisionTwist(player, effectiveness);
+            case "veil_break" -> performVeilBreak(player, effectiveness);
+            case "ember_boost" -> performEmberBoost(player, effectiveness);
+            case "ember_recovery" -> performEmberRecovery(player, effectiveness);
+            case "weapon_overdrive" -> performWeaponOverdrive(player, effectiveness);
+            case "legendary_summon" -> performLegendarySummon(player, effectiveness);
+            default -> player.sendMessage(messages.format("goblin.skill.unknown"));
+        }
+    }
+
+    private void performRushStrike(Player player, double effectiveness) {
+        Vector direction = player.getLocation().getDirection();
+        if (direction.lengthSquared() == 0) {
+            direction = new Vector(0, 0, 0);
+        }
+        Vector velocity = direction.normalize().multiply(1.4 * effectiveness);
+        velocity.setY(Math.max(0.35 * effectiveness, 0.25));
+        player.setVelocity(velocity);
+        player.getWorld().playSound(player.getLocation(), Sound.ENTITY_PLAYER_ATTACK_SWEEP, 1.2F, 0.75F);
+        player.getWorld().spawnParticle(Particle.SWEEP_ATTACK, player.getLocation().add(0, 1, 0), 12, 0.6, 0.2, 0.6, 0.01);
+        double damage = 6.0 * effectiveness + 4.0;
+        double radius = 2.5 + effectiveness;
+        LocationSnapshot snapshot = LocationSnapshot.of(player);
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            Collection<Entity> nearby = snapshot.world().getNearbyEntities(snapshot.location(), radius, radius, radius);
+            for (Entity entity : nearby) {
+                if (entity instanceof LivingEntity living && !living.getUniqueId().equals(player.getUniqueId())) {
+                    living.damage(damage, player);
+                    Vector knock = living.getLocation().toVector().subtract(player.getLocation().toVector()).normalize().multiply(0.5 * effectiveness);
+                    living.setVelocity(living.getVelocity().add(knock));
+                }
+            }
+            snapshot.world().spawnParticle(Particle.EXPLOSION, snapshot.location(), 24, 0.6, 0.4, 0.6, 0.05);
+        }, 8L);
+    }
+
+    private void performPursuitMark(Player player, double effectiveness) {
+        Entity targetEntity = player.getTargetEntity(25);
+        if (!(targetEntity instanceof LivingEntity target) || target.getUniqueId().equals(player.getUniqueId())) {
+            player.sendMessage(messages.format("goblin.skill.no_target"));
+            return;
+        }
+        int duration = (int) Math.round(200 * effectiveness + 60);
+        target.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, duration, 0, false, true, true));
+        target.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, (int) Math.round(60 * effectiveness + 40), 0, false, true, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, duration, effectiveness >= 0.9 ? 2 : 1, false, true, true));
+        player.getWorld().playSound(player.getLocation(), Sound.ENTITY_ENDER_DRAGON_FLAP, 0.8F, 1.4F);
+        player.getWorld().spawnParticle(Particle.END_ROD, target.getLocation().add(0, 1, 0), 20, 0.3, 0.7, 0.3, 0.01);
+    }
+
+    private void performVisionTwist(Player player, double effectiveness) {
+        double radius = 8.0 + 4.0 * effectiveness;
+        int blindness = (int) Math.round(80 * effectiveness + 60);
+        int confusion = (int) Math.round(140 * effectiveness + 80);
+        for (Entity entity : player.getWorld().getNearbyEntities(player.getLocation(), radius, radius, radius)) {
+            if (entity instanceof LivingEntity target && !target.getUniqueId().equals(player.getUniqueId())) {
+                target.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, blindness, 0, false, true, true));
+                target.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA, confusion, 0, false, true, true));
+            }
+        }
+        player.getWorld().playSound(player.getLocation(), Sound.ENTITY_EVOKER_CAST_SPELL, 1.0F, 0.6F);
+        player.getWorld().spawnParticle(Particle.WITCH, player.getLocation().add(0, 1, 0), 60, radius / 6, 1.0, radius / 6, 0.02);
+    }
+
+    private void performVeilBreak(Player player, double effectiveness) {
+        double radius = 12.0 * effectiveness + 6.0;
+        int duration = (int) Math.round(120 * effectiveness + 40);
+        for (Entity entity : player.getWorld().getNearbyEntities(player.getLocation(), radius, radius, radius)) {
+            if (entity instanceof LivingEntity target && !target.getUniqueId().equals(player.getUniqueId())) {
+                if (target.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
+                    target.removePotionEffect(PotionEffectType.INVISIBILITY);
+                }
+                target.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, duration, 0, false, true, true));
+            }
+        }
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_AMETHYST_CLUSTER_BREAK, 1.0F, 1.2F);
+        player.getWorld().spawnParticle(Particle.INSTANT_EFFECT, player.getLocation().add(0, 1, 0), 40, radius / 6, 0.8, radius / 6, 0.01);
+    }
+
+    private void performEmberBoost(Player player, double effectiveness) {
+        double radius = 10.0 + 4.0 * effectiveness;
+        int duration = (int) Math.round(200 * effectiveness + 100);
+        int strengthLevel = effectiveness >= 0.95 ? 1 : 0;
+        for (Entity entity : player.getWorld().getNearbyEntities(player.getLocation(), radius, radius, radius)) {
+            if (entity instanceof Player target) {
+                target.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, duration, strengthLevel, false, true, true));
+                target.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, duration, 0, false, true, true));
+                target.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, duration, 0, false, true, true));
+            }
+        }
+        player.getWorld().playSound(player.getLocation(), Sound.ITEM_FIRECHARGE_USE, 1.0F, 1.0F);
+        player.getWorld().spawnParticle(Particle.FLAME, player.getLocation().add(0, 1, 0), 120, radius / 5, 1.0, radius / 5, 0.05);
+    }
+
+    private void performEmberRecovery(Player player, double effectiveness) {
+        double healAmount = 6.0 * effectiveness + 2.0;
+        AttributeInstance maxHealth = player.getAttribute(Attribute.MAX_HEALTH);
+        if (maxHealth != null) {
+            player.setHealth(Math.min(maxHealth.getValue(), player.getHealth() + healAmount));
+        }
+        player.setFireTicks(0);
+        player.removePotionEffect(PotionEffectType.POISON);
+        player.removePotionEffect(PotionEffectType.WITHER);
+        int duration = (int) Math.round(80 * effectiveness + 40);
+        player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, duration, effectiveness >= 0.9 ? 1 : 0, false, true, true));
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_CAMPFIRE_CRACKLE, 1.0F, 1.2F);
+        player.getWorld().spawnParticle(Particle.HEART, player.getLocation().add(0, 1, 0), 12, 0.4, 0.6, 0.4, 0.02);
+    }
+
+    private void performWeaponOverdrive(Player player, double effectiveness) {
+        int duration = (int) Math.round(200 * effectiveness + 80);
+        int strengthLevel = effectiveness >= 0.95 ? 1 : 0;
+        player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, duration, strengthLevel, false, true, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, duration, 0, false, true, true));
+        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_SMITHING_TABLE_USE, 1.0F, 1.0F);
+        player.getWorld().spawnParticle(Particle.CRIT, player.getLocation().add(0, 1, 0), 50, 0.5, 0.7, 0.5, 0.1);
+    }
+
+    private void performLegendarySummon(Player player, double effectiveness) {
+        ItemStack sword = new ItemStack(org.bukkit.Material.NETHERITE_SWORD);
+        ItemMeta meta = sword.getItemMeta();
+        if (meta != null) {
+            meta.displayName(net.kyori.adventure.text.Component.text("전설의 화염검", net.kyori.adventure.text.format.NamedTextColor.GOLD));
+            meta.lore(List.of(
+                    Component.text("일시적 전설 무기", NamedTextColor.GOLD),
+                    Component.text("효율: " + (int) Math.round(effectiveness * 100) + "%", NamedTextColor.GRAY)
+            ));
+            meta.getPersistentDataContainer().set(legendaryWeaponKey, org.bukkit.persistence.PersistentDataType.BYTE, (byte) 1);
+            sword.setItemMeta(meta);
+        }
+        player.getInventory().addItem(sword);
+        int duration = (int) Math.round(200 * effectiveness + 160);
+        player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, duration, 1, false, true, true));
+        player.getWorld().playSound(player.getLocation(), Sound.ITEM_TRIDENT_THUNDER, 0.8F, 1.1F);
+        player.getWorld().spawnParticle(Particle.LAVA, player.getLocation().add(0, 1, 0), 80, 0.6, 1.0, 0.6, 0.08);
+        Bukkit.getScheduler().runTaskLater(plugin, () -> removeLegendaryWeapon(player), duration);
+    }
+
+    private void removeLegendaryWeapon(Player player) {
+        PlayerInventory inventory = player.getInventory();
+        boolean changed = false;
+        for (int slot = 0; slot < inventory.getSize(); slot++) {
+            ItemStack stack = inventory.getItem(slot);
+            if (isLegendaryWeapon(stack)) {
+                inventory.setItem(slot, null);
+                changed = true;
+            }
+        }
+        if (isLegendaryWeapon(inventory.getItemInOffHand())) {
+            inventory.setItemInOffHand(null);
+            changed = true;
+        }
+        if (changed) {
+            player.updateInventory();
+            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_ANVIL_LAND, 0.6F, 1.4F);
+        }
+    }
+
+    private boolean isLegendaryWeapon(ItemStack stack) {
+        if (stack == null || stack.getType().isAir()) {
+            return false;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        return meta != null && meta.getPersistentDataContainer().has(legendaryWeaponKey, org.bukkit.persistence.PersistentDataType.BYTE);
+    }
+
+    private void cleanupLegendaryWeapons(PlayerInventory inventory) {
+        for (int slot = 0; slot < inventory.getSize(); slot++) {
+            ItemStack stack = inventory.getItem(slot);
+            if (isLegendaryWeapon(stack)) {
+                NamespacedKey key = legendaryWeaponKey;
+                ItemMeta meta = stack.getItemMeta();
+                meta.getPersistentDataContainer().remove(key);
+                stack.setItemMeta(meta);
+            }
+        }
+    }
+
+    private boolean checkCooldown(UUID uuid, GoblinAspect aspect, GoblinSkill skill, int cooldown) {
+        Map<String, Long> map = cooldowns.get(uuid);
+        if (map == null) {
+            return true;
+        }
+        String composite = aspect.getKey() + ":" + skill.getKey();
+        Long until = map.get(composite);
+        if (until == null) {
+            return true;
+        }
+        return until <= System.currentTimeMillis();
+    }
+
+    private void registerCooldown(UUID uuid, GoblinAspect aspect, GoblinSkill skill, int cooldown) {
+        cooldowns.computeIfAbsent(uuid, key -> new ConcurrentHashMap<>())
+                .put(aspect.getKey() + ":" + skill.getKey(), System.currentTimeMillis() + cooldown * 1000L);
+    }
+
+    private long getRemainingCooldown(UUID uuid, GoblinAspect aspect, GoblinSkill skill) {
+        Map<String, Long> map = cooldowns.get(uuid);
+        if (map == null) {
+            return 0;
+        }
+        Long until = map.get(aspect.getKey() + ":" + skill.getKey());
+        if (until == null) {
+            return 0;
+        }
+        long remaining = until - System.currentTimeMillis();
+        return Math.max(0, remaining);
+    }
+
+    private String formatSeconds(long millis) {
+        long seconds = (long) Math.ceil(millis / 1000.0);
+        return seconds + "s";
+    }
+
+    private void applyPassive(GoblinAspect aspect, Player player, boolean inheritor) {
+        removePassive(aspect, player, inheritor);
+        switch (aspect) {
+            case POWER -> applyPowerPassive(player, inheritor ? 1.0D : aspect.getSharedPassiveRatio());
+            case SPEED -> applySpeedPassive(player, inheritor ? 1.0D : aspect.getSharedPassiveRatio());
+            default -> { /* no passive */ }
+        }
+    }
+
+    private void removePassive(GoblinAspect aspect, Player player, boolean inheritor) {
+        switch (aspect) {
+            case POWER -> player.removePotionEffect(PotionEffectType.RESISTANCE);
+            case SPEED -> {
+                player.removePotionEffect(PotionEffectType.SPEED);
+                cancelScentTask(player.getUniqueId());
+            }
+            default -> {
+                // no-op
+            }
+        }
+    }
+
+    private void applyPowerPassive(Player player, double ratio) {
+        int amplifier = ratio >= 0.95 ? 1 : 0;
+        int duration = Integer.MAX_VALUE;
+        player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, duration, amplifier, false, false, false));
+    }
+
+    private void applySpeedPassive(Player player, double ratio) {
+        int amplifier = ratio >= 0.9 ? 1 : 0;
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, Integer.MAX_VALUE, amplifier, false, false, false));
+        long interval = ratio >= 0.9 ? 100L : 160L;
+        BukkitTask task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!player.isOnline()) {
+                    cancel();
+                    return;
+                }
+                if (player.getGameMode() == GameMode.SPECTATOR) {
+                    return;
+                }
+                int count = 0;
+                for (Player nearby : player.getWorld().getPlayers()) {
+                    if (nearby.equals(player)) {
+                        continue;
+                    }
+                    if (nearby.getLocation().distanceSquared(player.getLocation()) <= 400) {
+                        count++;
+                    }
+                }
+                if (count > 0) {
+                    player.sendActionBar(net.kyori.adventure.text.Component.text(
+                            messages.format("goblin.passive.scent", Map.of("count", String.valueOf(count)))
+                    ));
+                }
+            }
+        }.runTaskTimer(plugin, interval, interval);
+        scentTasks.put(player.getUniqueId(), task);
+    }
+
+    private void cancelScentTask(UUID uuid) {
+        BukkitTask task = scentTasks.remove(uuid);
+        if (task != null) {
+            task.cancel();
+        }
+    }
+
+    private void applySharedEffects(GoblinAspect aspect, Player inheritor) {
+        // Shared effect placeholder for future expansion. Currently handles nothing beyond passives.
+    }
+
+    private void updateHealthPenalty(GoblinAspect aspect) {
+        AspectProfile profile = profiles.get(aspect);
+        if (profile.inheritor == null) {
+            return;
+        }
+        Player inheritor = Bukkit.getPlayer(profile.inheritor);
+        if (inheritor == null) {
+            return;
+        }
+        AttributeInstance attribute = inheritor.getAttribute(Attribute.MAX_HEALTH);
+        if (attribute == null) {
+            return;
+        }
+        NamespacedKey key = healthModifierKeys.get(aspect);
+        attribute.removeModifier(key);
+        int count = profile.shared.size();
+        if (count <= 0) {
+            return;
+        }
+        double penalty = count * HEALTH_PENALTY_PER_SHARE;
+        AttributeModifier modifier = new AttributeModifier(key, -penalty, AttributeModifier.Operation.ADD_NUMBER);
+        attribute.addModifier(modifier);
+        double maxHealth = attribute.getValue();
+        if (inheritor.getHealth() > maxHealth) {
+            inheritor.setHealth(maxHealth);
+        }
+    }
+
+    private void applyInheritorHealth(GoblinAspect aspect, Player player) {
+        AttributeInstance attribute = player.getAttribute(Attribute.MAX_HEALTH);
+        if (attribute == null) {
+            return;
+        }
+        UUID uuid = player.getUniqueId();
+        Set<GoblinAspect> active = activeInheritorAspects.computeIfAbsent(uuid, key -> new HashSet<>());
+        if (!active.contains(aspect)) {
+            if (active.isEmpty() && !originalMaxHealth.containsKey(uuid)) {
+                originalMaxHealth.put(uuid, attribute.getBaseValue());
+            }
+            active.add(aspect);
+        }
+        double target = aspect.getBaseMaxHealth();
+        if (attribute.getBaseValue() < target - 1.0E-3D) {
+            attribute.setBaseValue(target);
+        }
+        if (player.getHealth() > attribute.getBaseValue()) {
+            player.setHealth(attribute.getBaseValue());
+        }
+        pendingMaxHealthRestores.remove(uuid);
+    }
+
+    private void removeInheritorHealth(GoblinAspect aspect, UUID uuid, Player player) {
+        Set<GoblinAspect> active = activeInheritorAspects.get(uuid);
+        boolean restore = true;
+        if (active != null) {
+            active.remove(aspect);
+            if (active.isEmpty()) {
+                activeInheritorAspects.remove(uuid);
+            } else {
+                restore = false;
+            }
+        }
+        if (!restore) {
+            return;
+        }
+        Double original = originalMaxHealth.remove(uuid);
+        if (original == null) {
+            return;
+        }
+        if (player != null) {
+            AttributeInstance attribute = player.getAttribute(Attribute.MAX_HEALTH);
+            if (attribute != null) {
+                attribute.setBaseValue(original);
+                if (player.getHealth() > original) {
+                    player.setHealth(original);
+                }
+            }
+        } else {
+            pendingMaxHealthRestores.put(uuid, original);
+        }
+    }
+
+    private String describePowerProgress(Player player) {
+        AspectProfile profile = profiles.get(GoblinAspect.POWER);
+        if (profile.inheritor == null) {
+            return messages.format("goblin.progress.power.available");
+        }
+        if (profile.isInheritor(player.getUniqueId())) {
+            return messages.format("goblin.progress.power.self");
+        }
+        String holder = profile.name != null ? profile.name : messages.format("goblin.list.none");
+        return messages.format("goblin.progress.power.holder", Map.of("player", holder));
+    }
+
+    private String describeSpeedProgress(Player player) {
+        AspectProfile profile = profiles.get(GoblinAspect.SPEED);
+        UUID uuid = player.getUniqueId();
+        if (profile.inheritor != null) {
+            if (profile.isInheritor(uuid)) {
+                return messages.format("goblin.progress.speed.self");
+            }
+            String holder = profile.name != null ? profile.name : messages.format("goblin.list.none");
+            return messages.format("goblin.progress.speed.holder", Map.of("player", holder));
+        }
+        EnumSet<TraceToken> progress = speedProgress.get(uuid);
+        if (progress == null || progress.isEmpty()) {
+            return messages.format("goblin.progress.speed.none", Map.of(
+                    "eye", describeMaterial(speedTraceEyeItem),
+                    "horn", describeMaterial(speedTraceHornItem)
+            ));
+        }
+        boolean hasEye = progress.contains(TraceToken.EYE);
+        boolean hasHorn = progress.contains(TraceToken.HORN);
+        if (hasEye && hasHorn) {
+            return messages.format("goblin.progress.speed.ready");
+        }
+        if (hasEye) {
+            return messages.format("goblin.progress.speed.partial_eye", Map.of(
+                    "horn", describeMaterial(speedTraceHornItem)
+            ));
+        }
+        return messages.format("goblin.progress.speed.partial_horn", Map.of(
+                "eye", describeMaterial(speedTraceEyeItem)
+        ));
+    }
+
+    private String describeMischiefProgress(Player player) {
+        AspectProfile profile = profiles.get(GoblinAspect.MISCHIEF);
+        UUID uuid = player.getUniqueId();
+        if (profile.inheritor != null) {
+            if (profile.isInheritor(uuid)) {
+                return messages.format("goblin.progress.mischief.self");
+            }
+            String holder = profile.name != null ? profile.name : messages.format("goblin.list.none");
+            return messages.format("goblin.progress.mischief.holder", Map.of("player", holder));
+        }
+        ItemStack held = player.getInventory().getItemInMainHand();
+        if (held == null || held.getType().isAir() || !contractMaterials.contains(held.getType())) {
+            return messages.format("goblin.progress.mischief.need_item", Map.of(
+                    "items", describeMaterials(contractMaterials)
+            ));
+        }
+        if (!matchesContractKeywords(held)) {
+            return messages.format("goblin.progress.mischief.need_keyword", Map.of(
+                    "keywords", String.join(", ", contractKeywords)
+            ));
+        }
+        return messages.format("goblin.progress.mischief.ready");
+    }
+
+    private String describeFlameProgress(Player player) {
+        AspectProfile profile = profiles.get(GoblinAspect.FLAME);
+        UUID uuid = player.getUniqueId();
+        if (profile.inheritor != null) {
+            if (profile.isInheritor(uuid)) {
+                return messages.format("goblin.progress.flame.self");
+            }
+            String holder = profile.name != null ? profile.name : messages.format("goblin.list.none");
+            return messages.format("goblin.progress.flame.holder", Map.of("player", holder));
+        }
+        ItemStack held = player.getInventory().getItemInMainHand();
+        if (held == null || held.getType() != flameCatalyst) {
+            return messages.format("goblin.progress.flame.need_item", Map.of(
+                    "item", describeMaterial(flameCatalyst)
+            ));
+        }
+        return messages.format("goblin.progress.flame.ready", Map.of(
+                "blocks", describeMaterials(flameRitualBlocks)
+        ));
+    }
+
+    private String describeForgeProgress(Player player) {
+        AspectProfile profile = profiles.get(GoblinAspect.FORGE);
+        UUID uuid = player.getUniqueId();
+        if (profile.inheritor != null) {
+            if (profile.isInheritor(uuid)) {
+                return messages.format("goblin.progress.forge.self");
+            }
+            String holder = profile.name != null ? profile.name : messages.format("goblin.list.none");
+            return messages.format("goblin.progress.forge.holder", Map.of("player", holder));
+        }
+        PlayerInventory inventory = player.getInventory();
+        if (!inventory.contains(forgeCatalyst)) {
+            return messages.format("goblin.progress.forge.need_catalyst", Map.of(
+                    "item", describeMaterial(forgeCatalyst)
+            ));
+        }
+        if (!inventory.contains(forgeFuel)) {
+            return messages.format("goblin.progress.forge.need_fuel", Map.of(
+                    "item", describeMaterial(forgeFuel)
+            ));
+        }
+        if (!isNearForgeStation(player)) {
+            return messages.format("goblin.progress.forge.need_station", Map.of(
+                    "blocks", describeMaterials(forgeStations)
+            ));
+        }
+        return messages.format("goblin.progress.forge.ready");
+    }
+
+    private TraceToken traceTokenFromMaterial(Material material) {
+        if (material == null) {
+            return null;
+        }
+        if (material == speedTraceEyeItem) {
+            return TraceToken.EYE;
+        }
+        if (material == speedTraceHornItem) {
+            return TraceToken.HORN;
+        }
+        return null;
+    }
+
+    private String describeMaterial(Material material) {
+        if (material == null) {
+            return "";
+        }
+        String path = "goblin.material." + material.name();
+        String formatted = messages.format(path);
+        if (formatted.equals(path)) {
+            return material.name().toLowerCase(Locale.ROOT).replace('_', ' ');
+        }
+        return formatted;
+    }
+
+    private String describeMaterials(Collection<Material> materials) {
+        List<String> names = new ArrayList<>();
+        for (Material material : materials) {
+            names.add(describeMaterial(material));
+        }
+        return String.join(", ", names);
+    }
+
+    private boolean matchesContractKeywords(ItemStack stack) {
+        if (contractKeywords.isEmpty()) {
+            return true;
+        }
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) {
+            return false;
+        }
+        List<String> candidates = new ArrayList<>();
+        if (meta instanceof BookMeta bookMeta) {
+            String title = bookMeta.getTitle();
+            if (title != null) {
+                candidates.add(title);
+            }
+        }
+        if (meta.hasDisplayName()) {
+            Component component = meta.displayName();
+            if (component != null) {
+                candidates.add(PlainTextComponentSerializer.plainText().serialize(component));
+            }
+        }
+        for (String candidate : candidates) {
+            if (candidate == null) {
+                continue;
+            }
+            String normalized = candidate.toLowerCase(Locale.ROOT);
+            for (String keyword : contractKeywords) {
+                if (normalized.contains(keyword)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void consumeMainHand(Player player) {
+        PlayerInventory inventory = player.getInventory();
+        ItemStack held = inventory.getItemInMainHand();
+        if (held == null || held.getType().isAir()) {
+            return;
+        }
+        if (held.getAmount() <= 1) {
+            inventory.setItemInMainHand(null);
+        } else {
+            held.setAmount(held.getAmount() - 1);
+        }
+    }
+
+    private void igniteCampfire(Block block) {
+        BlockData data = block.getBlockData();
+        if (data instanceof Campfire campfire && !campfire.isLit()) {
+            campfire.setLit(true);
+            block.setBlockData(campfire);
+        }
+    }
+
+    private boolean isNearForgeStation(Player player) {
+        org.bukkit.Location center = player.getLocation();
+        World world = center.getWorld();
+        if (world == null) {
+            return false;
+        }
+        int vertical = Math.max(1, Math.min(forgeRadius, 2));
+        for (int x = -forgeRadius; x <= forgeRadius; x++) {
+            for (int y = -vertical; y <= vertical; y++) {
+                for (int z = -forgeRadius; z <= forgeRadius; z++) {
+                    Block block = world.getBlockAt(center.getBlockX() + x, center.getBlockY() + y, center.getBlockZ() + z);
+                    if (forgeStations.contains(block.getType())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean removeFromInventory(PlayerInventory inventory, Material material) {
+        for (int slot = 0; slot < inventory.getSize(); slot++) {
+            ItemStack stack = inventory.getItem(slot);
+            if (stack != null && stack.getType() == material) {
+                if (stack.getAmount() <= 1) {
+                    inventory.setItem(slot, null);
+                } else {
+                    stack.setAmount(stack.getAmount() - 1);
+                }
+                return true;
+            }
+        }
+        ItemStack offHand = inventory.getItemInOffHand();
+        if (offHand != null && offHand.getType() == material) {
+            if (offHand.getAmount() <= 1) {
+                inventory.setItemInOffHand(null);
+            } else {
+                offHand.setAmount(offHand.getAmount() - 1);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void broadcast(String message) {
+        plugin.broadcast(message);
+    }
+
+    private Material resolveMaterial(List<String> entries, int index, Material fallback) {
+        if (entries == null || index < 0 || index >= entries.size()) {
+            return fallback;
+        }
+        return resolveMaterial(entries.get(index), fallback);
+    }
+
+    private Material resolveMaterial(String raw, Material fallback) {
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+        Material material = Material.matchMaterial(raw.trim().toUpperCase(Locale.ROOT));
+        if (material == null) {
+            plugin.getLogger().warning("[Config] Unknown material '" + raw + "' - using " + fallback);
+            return fallback;
+        }
+        return material;
+    }
+
+    private Set<Material> resolveMaterialSet(List<String> entries, Set<Material> fallback) {
+        EnumSet<Material> result = EnumSet.noneOf(Material.class);
+        if (entries != null) {
+            for (String entry : entries) {
+                Material material = resolveMaterial(entry, null);
+                if (material != null) {
+                    result.add(material);
+                }
+            }
+        }
+        if (result.isEmpty()) {
+            result.addAll(fallback);
+        }
+        return result;
+    }
+
+    private List<String> buildKeywordList(List<String> entries, List<String> fallback) {
+        List<String> list = new ArrayList<>();
+        if (entries != null) {
+            for (String entry : entries) {
+                if (entry != null && !entry.isBlank()) {
+                    list.add(entry.toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+        if (list.isEmpty()) {
+            for (String entry : fallback) {
+                list.add(entry.toLowerCase(Locale.ROOT));
+            }
+        }
+        return Collections.unmodifiableList(list);
+    }
+
+    private enum TraceToken {
+        EYE,
+        HORN;
+
+        static TraceToken fromKey(String key) {
+            if (key == null) {
+                return null;
+            }
+            try {
+                return TraceToken.valueOf(key.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ex) {
+                return null;
+            }
+        }
+    }
+
+    private static final class AspectProfile {
+        private UUID inheritor;
+        private String name;
+        private final Set<UUID> shared = new HashSet<>();
+
+        boolean isInheritor(UUID uuid) {
+            return uuid != null && uuid.equals(inheritor);
+        }
+    }
+
+    private record LocationSnapshot(World world, org.bukkit.Location location) {
+        static LocationSnapshot of(Player player) {
+            return new LocationSnapshot(player.getWorld(), player.getLocation().clone());
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinAspect.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinAspect.java
@@ -1,0 +1,158 @@
+package me.j17e4eo.mythof5.inherit.aspect;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Describes the five primordial goblin aspects along with their skills and
+ * descriptive data. Concrete behaviour is executed by the
+ * {@link me.j17e4eo.mythof5.inherit.AspectManager}.
+ */
+public enum GoblinAspect {
+
+    POWER("power", "힘의 도깨비", "오만, 직선적.", "현신 격파",
+            buildPowerSkills(), 0.6D, 40),
+    SPEED("speed", "속도의 도깨비", "예민, 집요.", "흔적 수집",
+            buildSpeedSkills(), 0.5D, 40),
+    MISCHIEF("mischief", "교란의 도깨비", "불가해, 냉정.", "계약",
+            buildMischiefSkills(), 0.55D, 40),
+    FLAME("flame", "정기의 도깨비", "나눔, 고독.", "불씨 의례",
+            buildFlameSkills(), 0.7D, 40),
+    FORGE("forge", "대장장이 도깨비", "장인, 창조적.", "특수 제작 의식",
+            buildForgeSkills(), 0.5D, 40);
+
+    private static final Map<GoblinAspect, String> PASSIVE_KEYS = new EnumMap<>(GoblinAspect.class);
+
+    private final String key;
+    private final String displayName;
+    private final String personality;
+    private final String acquisition;
+    private final List<GoblinSkill> skills;
+    private final double sharedPassiveRatio;
+    private final int baseMaxHealth;
+
+    GoblinAspect(String key, String displayName, String personality, String acquisition,
+                 List<GoblinSkill> skills, double sharedPassiveRatio, int baseMaxHealth) {
+        this.key = key;
+        this.displayName = displayName;
+        this.personality = personality;
+        this.acquisition = acquisition;
+        this.skills = skills;
+        this.sharedPassiveRatio = sharedPassiveRatio;
+        this.baseMaxHealth = baseMaxHealth;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getPersonality() {
+        return personality;
+    }
+
+    public String getAcquisition() {
+        return acquisition;
+    }
+
+    public List<GoblinSkill> getSkills() {
+        return skills;
+    }
+
+    public double getSharedPassiveRatio() {
+        return sharedPassiveRatio;
+    }
+
+    public int getBaseMaxHealth() {
+        return baseMaxHealth;
+    }
+
+    public String getPassiveKey() {
+        return PASSIVE_KEYS.computeIfAbsent(this, aspect -> aspect.key + "_passive");
+    }
+
+    public static GoblinAspect fromKey(String token) {
+        if (token == null) {
+            return null;
+        }
+        String normalized = token.trim().toLowerCase(Locale.ROOT);
+        for (GoblinAspect aspect : values()) {
+            if (aspect.key.equals(normalized) || aspect.displayName.equalsIgnoreCase(normalized)) {
+                return aspect;
+            }
+        }
+        return null;
+    }
+
+    private static List<GoblinSkill> buildPowerSkills() {
+        List<GoblinSkill> list = new ArrayList<>();
+        list.add(new GoblinSkill("rush_strike", "돌진 일격", GoblinSkillCategory.ACTIVE,
+                35, 1.8D, 0.6D,
+                "전방으로 폭발적으로 돌진하여 경로의 적에게 큰 피해를 입힌다.",
+                "돌진 거리가 짧고 피해량이 감소한다."));
+        list.add(new GoblinSkill("stagger_guard", "경직 저항", GoblinSkillCategory.PASSIVE,
+                0, 1.0D, 0.6D,
+                "강한 의지로 경직에 거의 걸리지 않는다.",
+                "경직 저항이 일부만 부여된다."));
+        return Collections.unmodifiableList(list);
+    }
+
+    private static List<GoblinSkill> buildSpeedSkills() {
+        List<GoblinSkill> list = new ArrayList<>();
+        list.add(new GoblinSkill("pursuit_mark", "추격 표식", GoblinSkillCategory.ACTIVE,
+                30, 1.6D, 0.5D,
+                "응시한 적에게 표식을 새겨 위치를 추적하며 본인에게 가속을 부여한다.",
+                "표식 지속 시간이 짧고 가속 효과가 감소한다."));
+        list.add(new GoblinSkill("scent_reader", "기척 감지", GoblinSkillCategory.PASSIVE,
+                0, 1.0D, 0.5D,
+                "주변의 발자취와 기척을 읽어 위치를 파악한다.",
+                "기척 감지 범위와 빈도가 감소한다."));
+        return Collections.unmodifiableList(list);
+    }
+
+    private static List<GoblinSkill> buildMischiefSkills() {
+        List<GoblinSkill> list = new ArrayList<>();
+        list.add(new GoblinSkill("vision_twist", "시야 왜곡", GoblinSkillCategory.ACTIVE,
+                40, 1.7D, 0.55D,
+                "주변 적의 시야를 일그러뜨리고 방향 감각을 잃게 한다.",
+                "범위가 좁고 지속 시간이 짧다."));
+        list.add(new GoblinSkill("veil_break", "은신 탐지", GoblinSkillCategory.UTILITY,
+                25, 1.5D, 0.5D,
+                "주변 은신한 존재를 끌어내어 위치를 드러낸다.",
+                "감지 범위가 줄어들고 빛남 지속 시간이 짧다."));
+        return Collections.unmodifiableList(list);
+    }
+
+    private static List<GoblinSkill> buildFlameSkills() {
+        List<GoblinSkill> list = new ArrayList<>();
+        list.add(new GoblinSkill("ember_boost", "불씨 강화", GoblinSkillCategory.ACTIVE,
+                32, 1.6D, 0.7D,
+                "주변 아군의 공격과 저항을 함께 끌어올린다.",
+                "버프의 지속 시간과 강도가 줄어든다."));
+        list.add(new GoblinSkill("ember_recovery", "단기 회복", GoblinSkillCategory.UTILITY,
+                24, 1.4D, 0.65D,
+                "타오르는 불씨로 짧은 시간 재생과 해제를 부여한다.",
+                "회복량과 지속 시간이 줄어든다."));
+        return Collections.unmodifiableList(list);
+    }
+
+    private static List<GoblinSkill> buildForgeSkills() {
+        List<GoblinSkill> list = new ArrayList<>();
+        list.add(new GoblinSkill("weapon_overdrive", "무기 강화", GoblinSkillCategory.ACTIVE,
+                28, 1.7D, 0.5D,
+                "주 무기를 단기간 폭발적인 성능으로 개량한다.",
+                "강화 수치와 지속 시간이 감소한다."));
+        list.add(new GoblinSkill("legendary_summon", "일시적 전설 무기 소환", GoblinSkillCategory.ACTIVE,
+                60, 1.8D, 0.5D,
+                "전설급 무기를 소환해 잠시 다룬다.",
+                "소환 시간이 줄고 공격 강화가 감소한다."));
+        return Collections.unmodifiableList(list);
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinSkill.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinSkill.java
@@ -1,0 +1,73 @@
+package me.j17e4eo.mythof5.inherit.aspect;
+
+import java.util.Locale;
+
+/**
+ * Immutable description of a goblin skill. Behaviour is provided by the
+ * {@link me.j17e4eo.mythof5.inherit.AspectManager} which interprets the skill
+ * identifiers at runtime.
+ */
+public final class GoblinSkill {
+
+    private final String key;
+    private final String displayName;
+    private final GoblinSkillCategory category;
+    private final int baseCooldownSeconds;
+    private final double sharedCooldownMultiplier;
+    private final double sharedEffectiveness;
+    private final String description;
+    private final String sharedDescription;
+
+    public GoblinSkill(String key, String displayName, GoblinSkillCategory category,
+                       int baseCooldownSeconds, double sharedCooldownMultiplier,
+                       double sharedEffectiveness, String description,
+                       String sharedDescription) {
+        this.key = key.toLowerCase(Locale.ROOT);
+        this.displayName = displayName;
+        this.category = category;
+        this.baseCooldownSeconds = baseCooldownSeconds;
+        this.sharedCooldownMultiplier = sharedCooldownMultiplier;
+        this.sharedEffectiveness = sharedEffectiveness;
+        this.description = description;
+        this.sharedDescription = sharedDescription;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public GoblinSkillCategory getCategory() {
+        return category;
+    }
+
+    public int getBaseCooldownSeconds() {
+        return baseCooldownSeconds;
+    }
+
+    public double getSharedCooldownMultiplier() {
+        return sharedCooldownMultiplier;
+    }
+
+    public double getSharedEffectiveness() {
+        return sharedEffectiveness;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getSharedDescription() {
+        return sharedDescription;
+    }
+
+    public int getCooldownSeconds(boolean inheritor) {
+        if (inheritor) {
+            return baseCooldownSeconds;
+        }
+        return (int) Math.ceil(baseCooldownSeconds * sharedCooldownMultiplier);
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinSkillCategory.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinSkillCategory.java
@@ -1,0 +1,11 @@
+package me.j17e4eo.mythof5.inherit.aspect;
+
+/**
+ * Category of a goblin skill. The category is used purely for presentation and
+ * command filtering.
+ */
+public enum GoblinSkillCategory {
+    ACTIVE,
+    PASSIVE,
+    UTILITY
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/omens/OmenManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/omens/OmenManager.java
@@ -1,0 +1,111 @@
+package me.j17e4eo.mythof5.omens;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.chronicle.ChronicleEventType;
+import me.j17e4eo.mythof5.chronicle.ChronicleManager;
+import me.j17e4eo.mythof5.config.Messages;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Handles omen stage transitions and world feedback.
+ */
+public class OmenManager {
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private final ChronicleManager chronicleManager;
+    private final Map<OmenStage, String> messageKeys = new EnumMap<>(OmenStage.class);
+    private BukkitTask ghostFireTask;
+    private OmenStage currentStage;
+
+    public OmenManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager) {
+        this.plugin = plugin;
+        this.messages = messages;
+        this.chronicleManager = chronicleManager;
+        messageKeys.put(OmenStage.STARSHIFT, "omen.starshift");
+        messageKeys.put(OmenStage.GHOST_FIRE, "omen.ghost_fire");
+        messageKeys.put(OmenStage.SKYBREAK, "omen.skybreak");
+    }
+
+    public void trigger(OmenStage stage, String reason) {
+        currentStage = stage;
+        broadcast(messages.format(messageKeys.get(stage), Map.of("reason", reason != null ? reason : "")));
+        chronicleManager.logEvent(ChronicleEventType.OMEN,
+                messages.format("chronicle.omen", Map.of(
+                        "stage", stage.name(),
+                        "reason", reason != null ? reason : messages.format("omen.unknown_reason")
+                )), new ArrayList<>(Bukkit.getOnlinePlayers()));
+        applyStage(stage);
+    }
+
+    private void applyStage(OmenStage stage) {
+        cancelGhostFire();
+        switch (stage) {
+            case STARSHIFT -> applyStarshift();
+            case GHOST_FIRE -> applyGhostFire();
+            case SKYBREAK -> applySkybreak();
+        }
+    }
+
+    private void applyStarshift() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            player.playSound(player.getLocation(), Sound.MUSIC_DISC_OTHERSIDE, 0.5F, 1.2F);
+            player.sendActionBar(Component.text(messages.format("omen.starshift.actionbar"), NamedTextColor.LIGHT_PURPLE));
+        }
+    }
+
+    private void applyGhostFire() {
+        ghostFireTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : Bukkit.getOnlinePlayers()) {
+                    player.getWorld().spawnParticle(Particle.SOUL_FIRE_FLAME,
+                            player.getLocation().add(0, 1.5, 0), 20, 0.5, 0.8, 0.5, 0.01);
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 40L);
+    }
+
+    private void applySkybreak() {
+        for (World world : Bukkit.getWorlds()) {
+            world.setStorm(true);
+            world.setThundering(true);
+        }
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            player.playSound(player.getLocation(), Sound.AMBIENT_CAVE, 0.8F, 0.6F);
+            player.sendActionBar(Component.text(messages.format("omen.skybreak.actionbar"), NamedTextColor.RED));
+        }
+    }
+
+    private void cancelGhostFire() {
+        if (ghostFireTask != null) {
+            ghostFireTask.cancel();
+            ghostFireTask = null;
+        }
+    }
+
+    private void broadcast(String message) {
+        plugin.broadcast(message);
+    }
+
+
+    public void shutdown() {
+        cancelGhostFire();
+        for (World world : Bukkit.getWorlds()) {
+            world.setStorm(false);
+            world.setThundering(false);
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/omens/OmenStage.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/omens/OmenStage.java
@@ -1,0 +1,7 @@
+package me.j17e4eo.mythof5.omens;
+
+public enum OmenStage {
+    STARSHIFT,
+    GHOST_FIRE,
+    SKYBREAK
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicFusion.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicFusion.java
@@ -1,0 +1,36 @@
+package me.j17e4eo.mythof5.relic;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents a deterministic fusion between relics.
+ */
+public final class RelicFusion {
+
+    private final RelicType result;
+    private final List<RelicType> ingredients;
+    private final String description;
+
+    public RelicFusion(RelicType result, String description, RelicType... ingredients) {
+        this.result = result;
+        this.description = description;
+        this.ingredients = List.of(ingredients);
+    }
+
+    public RelicType getResult() {
+        return result;
+    }
+
+    public List<RelicType> getIngredients() {
+        return ingredients;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean matches(Set<RelicType> owned) {
+        return owned.containsAll(ingredients);
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicManager.java
@@ -1,0 +1,167 @@
+package me.j17e4eo.mythof5.relic;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.chronicle.ChronicleEventType;
+import me.j17e4eo.mythof5.chronicle.ChronicleManager;
+import me.j17e4eo.mythof5.config.Messages;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Manages relic ownership, granting and fusion logic.
+ */
+public class RelicManager {
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private final ChronicleManager chronicleManager;
+    private final Map<UUID, Set<RelicType>> relics = new HashMap<>();
+    private final List<RelicFusion> fusions = new ArrayList<>();
+    private File dataFile;
+    private YamlConfiguration dataConfig;
+
+    public RelicManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager) {
+        this.plugin = plugin;
+        this.messages = messages;
+        this.chronicleManager = chronicleManager;
+        fusions.add(new RelicFusion(RelicType.TRICK_AND_BIND,
+                "환영과 포획이 동시에 발현되는 강력한 설화",
+                RelicType.MANGTAE_HALABEOM, RelicType.DUNGAP_MOUSE));
+    }
+
+    public void load() {
+        plugin.getDataFolder().mkdirs();
+        dataFile = new File(plugin.getDataFolder(), "relics.yml");
+        if (!dataFile.exists()) {
+            dataConfig = new YamlConfiguration();
+            return;
+        }
+        dataConfig = YamlConfiguration.loadConfiguration(dataFile);
+        relics.clear();
+        for (String key : dataConfig.getKeys(false)) {
+            UUID uuid;
+            try {
+                uuid = UUID.fromString(key);
+            } catch (IllegalArgumentException ex) {
+                plugin.getLogger().warning("Invalid player UUID in relics.yml: " + key);
+                continue;
+            }
+            List<String> entries = dataConfig.getStringList(key);
+            Set<RelicType> set = new HashSet<>();
+            for (String entry : entries) {
+                RelicType type = RelicType.fromKey(entry);
+                if (type != null) {
+                    set.add(type);
+                }
+            }
+            relics.put(uuid, set);
+        }
+    }
+
+    public void save() {
+        if (dataConfig == null) {
+            dataConfig = new YamlConfiguration();
+        }
+        for (Map.Entry<UUID, Set<RelicType>> entry : relics.entrySet()) {
+            List<String> serialized = new ArrayList<>();
+            for (RelicType type : entry.getValue()) {
+                serialized.add(type.getKey());
+            }
+            dataConfig.set(entry.getKey().toString(), serialized);
+        }
+        try {
+            dataConfig.save(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to save relics.yml: " + e.getMessage());
+        }
+    }
+
+    public boolean grantRelic(Player player, RelicType type, boolean announce) {
+        Set<RelicType> owned = relics.computeIfAbsent(player.getUniqueId(), key -> new HashSet<>());
+        if (!owned.add(type)) {
+            return false;
+        }
+        if (announce) {
+            player.sendMessage(messages.format("relic.obtain.self", Map.of(
+                    "relic", type.getDisplayName(),
+                    "effect", type.getEffect()
+            )));
+            plugin.broadcast(messages.format("relic.obtain.broadcast", Map.of(
+                    "player", player.getName(),
+                    "relic", type.getDisplayName()
+            )));
+        }
+        chronicleManager.logEvent(ChronicleEventType.RELIC_GAIN,
+                messages.format("chronicle.relic.obtain", Map.of(
+                        "player", player.getName(),
+                        "relic", type.getDisplayName()
+                )), List.of(player));
+        checkFusions(player, owned);
+        save();
+        return true;
+    }
+
+    public boolean removeRelic(Player player, RelicType type) {
+        Set<RelicType> owned = relics.get(player.getUniqueId());
+        if (owned == null) {
+            return false;
+        }
+        boolean removed = owned.remove(type);
+        if (removed) {
+            save();
+        }
+        return removed;
+    }
+
+    public Set<RelicType> getRelics(UUID uuid) {
+        return relics.containsKey(uuid) ? Collections.unmodifiableSet(relics.get(uuid)) : Collections.emptySet();
+    }
+
+    public List<RelicFusion> getFusions() {
+        return Collections.unmodifiableList(fusions);
+    }
+
+    public List<String> describeRelics(UUID uuid) {
+        Set<RelicType> owned = relics.get(uuid);
+        if (owned == null || owned.isEmpty()) {
+            return List.of(messages.format("relic.none"));
+        }
+        List<String> result = new ArrayList<>();
+        for (RelicType type : owned) {
+            result.add("• " + type.getDisplayName() + " - " + type.getEffect());
+        }
+        return result;
+    }
+
+    private void checkFusions(Player player, Set<RelicType> owned) {
+        for (RelicFusion fusion : fusions) {
+            if (!owned.contains(fusion.getResult()) && fusion.matches(owned)) {
+                owned.add(fusion.getResult());
+                player.sendMessage(messages.format("relic.fusion.self", Map.of(
+                        "relic", fusion.getResult().getDisplayName(),
+                        "desc", fusion.getDescription()
+                )));
+                plugin.broadcast(messages.format("relic.fusion.broadcast", Map.of(
+                        "player", player.getName(),
+                        "relic", fusion.getResult().getDisplayName()
+                )));
+                chronicleManager.logEvent(ChronicleEventType.RELIC_FUSION,
+                        messages.format("chronicle.relic.fusion", Map.of(
+                                "player", player.getName(),
+                                "relic", fusion.getResult().getDisplayName()
+                        )), List.of(player));
+            }
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicType.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicType.java
@@ -1,0 +1,51 @@
+package me.j17e4eo.mythof5.relic;
+
+import java.util.Locale;
+
+/**
+ * The smaller tales (설화) used as tactical relics on the server.
+ */
+public enum RelicType {
+    MANGTAE_HALABEOM("mangtae_halabeom", "망태할아범", "단시간 상대를 포획해 묶어둔다."),
+    WATER_GOBLIN("water_goblin", "물도깨비", "수중 전투에서 이동과 호흡이 강화된다."),
+    GUMIHO_TAIL("gumiho_tail", "구미호 꼬리", "환영 분신을 만들어 교란한다."),
+    DOOR_GUARD("door_guard", "문지기 도깨비", "문과 포탈을 봉인하여 추격을 저지한다."),
+    DUNGAP_MOUSE("dungap_mouse", "둔갑쥐", "작은 동물로 둔갑해 위기를 모면한다."),
+    PACK_ELDER("pack_elder", "등짐 노인", "자원을 빠르게 운반하고 획득 효율을 높인다."),
+    TRICK_AND_BIND("trick_and_bind", "속임과 구속의 설화", "환영으로 적을 유인하고 동시에 결박한다.");
+
+    private final String key;
+    private final String displayName;
+    private final String effect;
+
+    RelicType(String key, String displayName, String effect) {
+        this.key = key;
+        this.displayName = displayName;
+        this.effect = effect;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getEffect() {
+        return effect;
+    }
+
+    public static RelicType fromKey(String token) {
+        if (token == null) {
+            return null;
+        }
+        String normalized = token.trim().toLowerCase(Locale.ROOT);
+        for (RelicType type : values()) {
+            if (type.key.equals(normalized) || type.displayName.equalsIgnoreCase(normalized)) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/mythof5/src/main/resources/messages.yml
+++ b/mythof5/src/main/resources/messages.yml
@@ -3,11 +3,18 @@ commands:
     no_permission: "권한이 없습니다."
     player_only: "플레이어만 사용 가능한 명령어입니다."
     usage_header: "사용법:"
+    player_not_online: "해당 플레이어는 온라인이 아닙니다."
   myth:
     usage:
       - "{label} admin spawnboss <엔티티타입> <이름> [hp] [armor] [world] [x y z]"
       - "{label} admin bosslist"
       - "{label} admin endboss <bossId>"
+      - "{label} admin inherit <갈래> <플레이어>"
+      - "{label} admin clearinherit <갈래>"
+      - "{label} admin relic <give|remove> <플레이어> <설화>"
+      - "{label} admin chronicle [개수]"
+      - "{label} admin omen <단계> [사유]"
+      - "{label} admin balance"
     invalid_entity: "지원하지 않는 엔티티 타입입니다."
     entity_not_living: "해당 엔티티 타입은 보스로 사용할 수 없습니다."
     invalid_health: "hp 값은 1 이상이어야 합니다."
@@ -74,9 +81,190 @@ broadcast:
   squad_joined: "[방송] {player}가 부대 {squad}에 합류했습니다."
   squad_left: "[방송] {player}가 부대 {squad}에서 탈퇴했습니다."
   squad_disbanded: "[방송] 부대 {squad}이(가) 해산되었습니다."
+  goblin_inherit: "[방송] {player}가 {aspect}의 힘을 계승했다!"
 inherit:
   previous_replaced: "도깨비의 힘이 다른 계승자에게 이전되었습니다."
   broadcast:
     gain: "[방송] {player}가 {boss}를 쓰러뜨리고 힘을 계승했다!"
     transfer: "[방송] {killer}가 {victim}을 처치하고 힘을 차지했다!"
     loss: "[방송] {player}가 쓰러져 도깨비의 힘이 사라졌다."
+goblin:
+  usage:
+    - "{label} info"
+    - "{label} skills [갈래]"
+    - "{label} skill <스킬코드>"
+    - "{label} progress"
+    - "{label} share <갈래> <플레이어>"
+    - "{label} reclaim <갈래> <플레이어>"
+    - "{label} contract"
+    - "{label} forge"
+    - "{label} list"
+  skill:
+    no_target: "표식으로 지정할 대상을 찾지 못했습니다."
+    passive: "패시브 스킬은 명령어로 사용할 수 없습니다."
+    cooldown: "아직 식지 않았습니다! 남은 시간: {time}"
+    unknown: "해당 스킬은 존재하지 않습니다."
+  skills:
+    header: "===== 도깨비 스킬 사전 ====="
+    aspect: "• {aspect} (코드: {key})"
+    entry:
+      active: "  - {name} ({code}) [쿨타임 {cooldown}] : {desc}"
+      utility: "  - {name} ({code}) [유틸 {cooldown}] : {desc}"
+      passive: "  - {name} ({code}) [패시브] : {desc}"
+  info:
+    header: "===== 계승한 도깨비 목록 ====="
+    none: "당신에게 속한 도깨비의 힘이 없습니다."
+    aspect: "• {aspect} ({personality}) - 획득법: {acquire}"
+    skill:
+      active: "  - {name} ({code}) : {desc}"
+      passive: "  - {name} [패시브] : {desc}"
+  aspect:
+    unknown: "알 수 없는 도깨비 갈래입니다."
+    not_holder: "해당 도깨비의 계승자가 아니어서 분배할 수 없습니다."
+  share:
+    success: "{player}에게 {aspect}의 힘 일부를 나누었습니다."
+    received: "{player}가 {aspect}의 힘을 나누어 주었습니다."
+    duplicate: "이미 힘을 나누어 준 상태입니다."
+  reclaim:
+    success: "{player}에게서 {aspect}의 힘을 회수했습니다."
+    notice: "{aspect}의 힘이 회수되었습니다."
+    missing: "해당 플레이어는 힘을 분배받지 않았습니다."
+  list:
+    entry: "{aspect} - 계승자: {holder}"
+    none: "아직 계승자가 없다"
+  passive:
+    scent: "주변 기척 {count}건이 감지되었다."
+  progress:
+    header: "===== 다섯 갈래 진행도 ====="
+    power:
+      available: "힘의 도깨비: 현신을 쓰러뜨릴 계승자를 기다리고 있다."
+      self: "힘의 도깨비: 너의 주먹에 오만한 힘이 깃들어 있다."
+      holder: "힘의 도깨비: {player}가 현신을 격파하여 힘을 쥐었다."
+    speed:
+      none: "속도의 도깨비: {eye}와 {horn} 흔적을 모두 모아야 한다."
+      partial_eye: "속도의 도깨비: 눈 조각은 모았다. 이제 {horn}이 필요하다."
+      partial_horn: "속도의 도깨비: 뿔 조각은 모았다. 이제 {eye}가 필요하다."
+      ready: "속도의 도깨비: 두 흔적이 공명한다! 힘이 곧 응답할 것이다."
+      self: "속도의 도깨비: 너의 발걸음이 추격의 흔적을 따라 달린다."
+      holder: "속도의 도깨비: {player}가 흔적을 모아 권능을 얻었다."
+    mischief:
+      need_item: "교란의 도깨비: {items}을 손에 쥐고 계약서를 준비해야 한다."
+      need_keyword: "교란의 도깨비: 계약서에 {keywords}라는 약속을 새겨야 한다."
+      ready: "교란의 도깨비: 서약이 완성되었다. /goblin contract 로 서명하라."
+      self: "교란의 도깨비: 이미 네가 계약을 체결했다."
+      holder: "교란의 도깨비: {player}가 계약을 독점하고 있다."
+    flame:
+      need_item: "정기의 도깨비: {item}을 손에 쥐고 의식을 준비하라."
+      ready: "정기의 도깨비: {blocks}에 불씨를 흩뿌려 의식을 치르라."
+      self: "정기의 도깨비: 네 불씨가 들판을 밝힌다."
+      holder: "정기의 도깨비: {player}가 불씨 의례를 완수했다."
+    forge:
+      need_catalyst: "대장장이 도깨비: {item}이 없으면 의식을 시작할 수 없다."
+      need_fuel: "대장장이 도깨비: {item}을 더해 불을 지펴야 한다."
+      need_station: "대장장이 도깨비: {blocks} 근처의 공방에서 의식을 열어라."
+      ready: "대장장이 도깨비: 모든 재료가 모였다. /goblin forge 로 의식을 진행하라."
+      self: "대장장이 도깨비: 네 망치가 전설을 빚고 있다."
+      holder: "대장장이 도깨비: {player}가 장인의 불씨를 붙잡았다."
+  contract:
+    require_item: "계약을 맺으려면 {items}을 손에 쥐고 있어야 한다."
+    require_keyword: "계약서에 {keywords}라는 문구를 새겨야 한다."
+    taken: "{player}가 이미 교란의 도깨비와 계약을 맺었다."
+    already_holder: "이미 교란의 도깨비와 계약한 상태다."
+    success: "{aspect}와의 계약이 성립했다!"
+  ritual:
+    speed:
+      collect:
+        eye: "눈 조각의 흔적({item})을 챙겼다."
+        horn: "뿔 조각의 흔적({item})을 챙겼다."
+      progress: "흔적 {current}/{total} 조각이 모였다."
+      complete: "두 흔적이 공명하며 속도의 도깨비가 모습을 드러낸다!"
+    flame:
+      require_item: "불씨 의례에는 {item}이 필요하다."
+      success: "불씨가 타올라 정기의 도깨비가 응답했다!"
+    forge:
+      already: "대장장이 도깨비의 힘은 이미 네 것이다."
+      taken: "{player}가 이미 대장장이 도깨비를 모셨다."
+      require_catalyst: "{item}이 없이는 의식이 진행되지 않는다."
+      require_fuel: "{item}으로 화력을 더해야 한다."
+      require_station: "{blocks} 근처에서만 의식을 치를 수 있다."
+      success: "불과 쇠가 어우러지며 대장장이 도깨비가 손을 내민다!"
+  material:
+    BLAZE_POWDER: "블레이즈 파우더"
+    NETHERITE_INGOT: "네더라이트 주괴"
+    BLAZE_ROD: "블레이즈 막대"
+    SNOWBALL: "눈 조각"
+    GOAT_HORN: "뿔 조각"
+    WRITTEN_BOOK: "서명된 책"
+    WRITABLE_BOOK: "책과 깃펜"
+    CAMPFIRE: "캠프파이어"
+    SOUL_CAMPFIRE: "푸른 캠프파이어"
+    SMITHING_TABLE: "대장장이 작업대"
+    ANVIL: "모루"
+relic:
+  usage:
+    - "{label} list"
+    - "{label} fusions"
+  obtain:
+    self: "새 설화 '{relic}'을(를) 발견했다! 효과: {effect}"
+    broadcast: "[방송] {player}가 설화 '{relic}'을(를) 획득했다!"
+  fusion:
+    self: "설화가 융합되어 '{relic}'이(가) 깨어났다!"
+    broadcast: "[방송] {player}가 설화를 합쳐 '{relic}'을(를) 만들어냈다!"
+    header: "=== 설화 융합 목록 ==="
+    entry: "{ingredients} → {result} ({desc})"
+    none: "알려진 설화 융합이 없습니다."
+  none: "보유한 설화가 없습니다."
+  unknown: "알 수 없는 설화입니다."
+chronicle:
+  empty: "아직 연대기에 기록된 사건이 없다."
+  default:
+    inherit: "누군가 힘을 계승하였도다."
+    loss: "누군가 쓰러져 힘이 흩어졌도다."
+    share: "힘이 갈라져 나누어졌도다."
+    skill: "어떤 기술이 밤하늘을 가르렀도다."
+    relic_gain: "작은 설화 하나가 새로이 깃들었도다."
+    relic_fusion: "설화가 합쳐져 기묘한 기운이 솟았도다."
+    omen: "세상에 전조가 일어났도다."
+  inherit:
+    transfer: "{killer}, {victim}을 꺾고 {aspect}의 힘을 차지하였도다."
+    obtain: "{player}, {aspect}의 힘을 얻기 위해 {method}를 이루었도다."
+    force: "{player}, 명에 따라 {aspect}의 힘을 이어받았도다."
+    loss: "{player}, {aspect}의 힘을 잃고 허공으로 사라졌도다."
+    share: "{player}, {target}에게 {aspect}의 불씨를 떼어주었도다."
+  relic:
+    obtain: "{player}, 설화 '{relic}'을 품었도다."
+    fusion: "{player}, 설화를 얽어 '{relic}'을 빚어냈도다."
+  skill:
+    use: "{player}, {aspect}의 권능 '{skill}'을 펼쳤도다."
+  omen: "{stage}의 전조가 드러났으니, {reason}라 하도다."
+  inherit_loss: "{player}, {aspect}과의 인연이 끊어졌도다."
+commands.admin:
+  usage:
+    - "{label} admin spawnboss <엔티티타입> <이름> [hp] [armor] [world] [x y z]"
+    - "{label} admin bosslist"
+    - "{label} admin endboss <bossId>"
+    - "{label} admin inherit <갈래> <플레이어>"
+    - "{label} admin clearinherit <갈래>"
+    - "{label} admin relic <give|remove> <플레이어> <설화>"
+    - "{label} admin chronicle [개수]"
+    - "{label} admin omen <단계> [사유]"
+    - "{label} admin balance"
+  inherit_usage: "사용법: /myth admin inherit <갈래> <플레이어>"
+  inherit_success: "{player}에게 {aspect}의 힘을 부여했습니다."
+  clear_usage: "사용법: /myth admin clearinherit <갈래>"
+  clear_success: "{aspect}의 계승자를 초기화했습니다."
+  relic_usage: "사용법: /myth admin relic <give|remove> <플레이어> <설화>"
+  relic_duplicate: "이미 해당 설화를 보유하고 있습니다."
+  relic_grant: "{player}에게 {relic}을(를) 부여했습니다."
+  relic_removed: "{player}에게서 {relic}을(를) 회수했습니다."
+  relic_not_owned: "해당 설화를 보유하고 있지 않습니다."
+  omen_usage: "사용법: /myth admin omen <STARSHIFT|GHOST_FIRE|SKYBREAK> [사유]"
+  omen_unknown: "알 수 없는 전조 단계입니다."
+  omen_triggered: "{stage} 전조를 호출했습니다. 사유: {reason}"
+omen:
+  starshift: "[전조] 별자리가 뒤틀리며 속삭임이 들려온다."
+  ghost_fire: "[전조] 도깨비불이 들판을 가득 메우기 시작한다."
+  skybreak: "[전조] 하늘빛이 찢어지고 번개가 전 서버를 뒤덮는다."
+  starshift.actionbar: "별자리의 배열이 낯설게 뒤엉켰다."
+  skybreak.actionbar: "하늘이 붉게 갈라진다!"
+  unknown_reason: "이유는 아무도 모른다"

--- a/mythof5/src/main/resources/plugin.yml
+++ b/mythof5/src/main/resources/plugin.yml
@@ -12,6 +12,14 @@ commands:
     aliases: [sq]
     usage: /squad <subcommand>
     permission: myth.user.squad.*
+  goblin:
+    description: Goblin aspect commands
+    usage: /goblin <subcommand>
+    permission: myth.user.goblin
+  relic:
+    description: Relic overview commands
+    usage: /relic <subcommand>
+    permission: myth.user.relic
 permissions:
   myth.admin.*:
     description: Full access to myth admin commands
@@ -20,6 +28,9 @@ permissions:
       myth.admin.spawnboss: true
       myth.admin.bosslist: true
       myth.admin.endboss: true
+      myth.admin.inherit: true
+      myth.admin.relic: true
+      myth.admin.omen: true
   myth.admin.spawnboss:
     description: Spawn a dokkaebi boss
     default: op
@@ -28,6 +39,15 @@ permissions:
     default: op
   myth.admin.endboss:
     description: Forcefully end a boss
+    default: op
+  myth.admin.inherit:
+    description: Force assign or clear goblin inheritances
+    default: op
+  myth.admin.relic:
+    description: Grant or revoke relics
+    default: op
+  myth.admin.omen:
+    description: Trigger omen stages
     default: op
   myth.user.squad.*:
     description: Access to squad commands
@@ -56,4 +76,10 @@ permissions:
     default: true
   myth.user.squad.status:
     description: View squad status
+    default: true
+  myth.user.goblin:
+    description: Use goblin aspect commands
+    default: true
+  myth.user.relic:
+    description: Use relic commands
     default: true


### PR DESCRIPTION
## Summary
- load goblin trigger items from configuration while tracking trace, contract, ritual, and forge progress in the aspect manager
- wire pickups and campfire interactions into the player listener so inheritors can advance rituals naturally
- expand goblin command output/messages with help, skill encyclopedia, and progress feedback for better usability

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cb38bacbb08324b4db12e3feae0f7a