### PR TITLE
Implement aspect-specific goblin transformation profiles

### DIFF
--- a/mythof5/src/main/java/me/j17e4eo/mythof5/Mythof5.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/Mythof5.java
@@ -58,11 +58,11 @@ public final class Mythof5 extends JavaPlugin {
         omenManager = new OmenManager(this, messages, chronicleManager);
         balanceTable = new BalanceTable();
 
-        inheritManager = new InheritManager(this, messages);
-        inheritManager.load();
-
         aspectManager = new AspectManager(this, messages, chronicleManager, relicManager, omenManager);
         aspectManager.load();
+
+        inheritManager = new InheritManager(this, messages, aspectManager);
+        inheritManager.load();
 
         bossManager = new BossManager(this, inheritManager, aspectManager, messages);
         squadManager = new SquadManager(this, messages);
@@ -199,8 +199,24 @@ public final class Mythof5 extends JavaPlugin {
                 "generic.attack_damage:add:2"
         ));
         config.addDefault("inherit.announce", true);
-        config.addDefault("inherit.transformation.scale_multiplier", 2.0D);
-        config.addDefault("inherit.transformation.attack_bonus", 6.0D);
+        config.addDefault("inherit.transformation.default.scale_multiplier", 2.0D);
+        config.addDefault("inherit.transformation.default.attack_bonus", 6.0D);
+        config.addDefault("inherit.transformation.default.speed_bonus", 0.0D);
+        config.addDefault("inherit.transformation.aspects.power.scale_multiplier", 2.4D);
+        config.addDefault("inherit.transformation.aspects.power.attack_bonus", 9.0D);
+        config.addDefault("inherit.transformation.aspects.power.speed_bonus", 0.02D);
+        config.addDefault("inherit.transformation.aspects.speed.scale_multiplier", 1.8D);
+        config.addDefault("inherit.transformation.aspects.speed.attack_bonus", 4.0D);
+        config.addDefault("inherit.transformation.aspects.speed.speed_bonus", 0.08D);
+        config.addDefault("inherit.transformation.aspects.mischief.scale_multiplier", 1.9D);
+        config.addDefault("inherit.transformation.aspects.mischief.attack_bonus", 5.0D);
+        config.addDefault("inherit.transformation.aspects.mischief.speed_bonus", 0.05D);
+        config.addDefault("inherit.transformation.aspects.flame.scale_multiplier", 2.1D);
+        config.addDefault("inherit.transformation.aspects.flame.attack_bonus", 5.5D);
+        config.addDefault("inherit.transformation.aspects.flame.speed_bonus", 0.04D);
+        config.addDefault("inherit.transformation.aspects.forge.scale_multiplier", 2.35D);
+        config.addDefault("inherit.transformation.aspects.forge.attack_bonus", 8.0D);
+        config.addDefault("inherit.transformation.aspects.forge.speed_bonus", -0.01D);
         config.addDefault("goblin.triggers.power.boss_keywords", List.of("태초의 도깨비"));
         config.addDefault("goblin.triggers.speed.trace_items", List.of("SNOWBALL", "GOAT_HORN"));
         config.addDefault("goblin.triggers.mischief.contract_items", List.of("WRITTEN_BOOK", "WRITABLE_BOOK"));

--- a/mythof5/src/main/resources/config.yml
+++ b/mythof5/src/main/resources/config.yml
@@ -10,8 +10,31 @@ inherit:
     - "generic.attack_damage:add:2"
   announce: true
   transformation:
-    scale_multiplier: 2.0
-    attack_bonus: 6.0
+    default:
+      scale_multiplier: 2.0
+      attack_bonus: 6.0
+      speed_bonus: 0.0
+    aspects:
+      power:
+        scale_multiplier: 2.4
+        attack_bonus: 9.0
+        speed_bonus: 0.02
+      speed:
+        scale_multiplier: 1.8
+        attack_bonus: 4.0
+        speed_bonus: 0.08
+      mischief:
+        scale_multiplier: 1.9
+        attack_bonus: 5.0
+        speed_bonus: 0.05
+      flame:
+        scale_multiplier: 2.1
+        attack_bonus: 5.5
+        speed_bonus: 0.04
+      forge:
+        scale_multiplier: 2.35
+        attack_bonus: 8.0
+        speed_bonus: -0.01
 squad:
   max_members: 5
   friendly_fire: false


### PR DESCRIPTION
## Summary
- compute goblin transformation attributes per aspect and apply scale, attack, and speed bonuses dynamically
- add per-aspect transformation defaults and update the public configuration to expose the new knobs
- instantiate the aspect manager before the inherit manager so transformation logic can inspect aspect state

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cb773a9a188324a5fec5c1b0541b72