### PR TITLE
feat: add goblin transformation selection menu

### DIFF
--- a/mythof5/src/main/java/me/j17e4eo/mythof5/Mythof5.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/Mythof5.java
@@ -73,6 +73,7 @@ public final class Mythof5 extends JavaPlugin {
         PlayerListener playerListener = new PlayerListener(bossManager, inheritManager, aspectManager,
                 doubleJumpEnabled, doubleJumpVerticalVelocity, doubleJumpForwardMultiplier);
         pluginManager.registerEvents(playerListener, this);
+        pluginManager.registerEvents(inheritManager, this);
         pluginManager.registerEvents(new SquadListener(squadManager, getConfig().getBoolean("squad.friendly_fire", false), messages), this);
 
         registerCommands();

--- a/mythof5/src/main/resources/messages.yml
+++ b/mythof5/src/main/resources/messages.yml
@@ -37,6 +37,9 @@ commands:
     activated: "도깨비화가 발동되었습니다!"
     deactivated: "도깨비화를 해제했습니다."
     not_inheritor: "도깨비의 힘을 가진 플레이어만 사용할 수 있습니다."
+    select_prompt: "변신할 도깨비의 힘을 선택하세요."
+    select_hint: "좌클릭하여 변신합니다."
+    select_cancelled: "변신이 취소되었습니다."
   squad:
     usage:
       - "{label} create <이름>"


### PR DESCRIPTION
## Summary
- add a goblin transformation chest menu that appears when multiple aspects are owned, remembering the chosen profile and filtering icons to owned powers
- register the inherit manager as a listener and add localized prompts for the new selection flow

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cb8e7c40c883249e0a06cb0a7b46c2