### PR TITLE
Add hunter route system

### DIFF
--- a/mythof5/src/main/java/me/j17e4eo/mythof5/chronicle/ChronicleEventType.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/chronicle/ChronicleEventType.java
@@ -11,5 +11,10 @@ public enum ChronicleEventType {
     SKILL,
     RELIC_GAIN,
     RELIC_FUSION,
-    OMEN
+    OMEN,
+    HUNTER_ENGRAVE,
+    HUNTER_ARTIFACT,
+    HUNTER_BURNED,
+    HUNTER_RELEASE,
+    HUNTER_RESET
 }

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/HunterListener.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/HunterListener.java
@@ -1,0 +1,34 @@
+package me.j17e4eo.mythof5.hunter;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+
+/**
+ * Bridges Bukkit events into the hunter manager lifecycle.
+ */
+public class HunterListener implements Listener {
+
+    private final HunterManager hunterManager;
+
+    public HunterListener(HunterManager hunterManager) {
+        this.hunterManager = hunterManager;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        hunterManager.handleJoin(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onRespawn(PlayerRespawnEvent event) {
+        hunterManager.handleJoin(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        hunterManager.handleDeath(event.getEntity());
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/HunterManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/HunterManager.java
@@ -1,0 +1,545 @@
+package me.j17e4eo.mythof5.hunter;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.chronicle.ChronicleEventType;
+import me.j17e4eo.mythof5.chronicle.ChronicleManager;
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.hunter.data.Artifact;
+import me.j17e4eo.mythof5.hunter.data.ArtifactAbility;
+import me.j17e4eo.mythof5.hunter.data.ArtifactGrade;
+import me.j17e4eo.mythof5.hunter.data.ArtifactOrigin;
+import me.j17e4eo.mythof5.hunter.data.ArtifactState;
+import me.j17e4eo.mythof5.hunter.data.ArtifactType;
+import me.j17e4eo.mythof5.hunter.data.HunterOmenStage;
+import me.j17e4eo.mythof5.hunter.data.HunterProfile;
+import me.j17e4eo.mythof5.hunter.data.SealLogEntry;
+import me.j17e4eo.mythof5.hunter.event.HunterReleaseEvent;
+import me.j17e4eo.mythof5.hunter.math.SealMath;
+import me.j17e4eo.mythof5.hunter.test.HunterTestHook;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Runtime manager for the hunter route system.
+ */
+public class HunterManager {
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private final ChronicleManager chronicleManager;
+    private final SealMath sealMath;
+    private final Map<ArtifactGrade, Double> gaugeOverrides = new EnumMap<>(ArtifactGrade.class);
+    private final Map<UUID, HunterProfile> profiles = new HashMap<>();
+    private final Map<UUID, HunterTestHook> testHooks = new LinkedHashMap<>();
+    private final Random random = new Random();
+    private final double sealPatchValue;
+    private final double deathIntegrityDecay;
+    private final double witnessRadius;
+    private final long broadcastCooldownMillis;
+    private final int longThreshold;
+    private final int mediumThreshold;
+    private final int lateThreshold;
+    private File dataFile;
+    private YamlConfiguration dataConfig;
+    private long lastBroadcast;
+    private ParadoxManager paradoxManager;
+
+    public HunterManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager, SealMath sealMath,
+                         double sealPatchValue, double deathIntegrityDecay, double witnessRadius,
+                         long broadcastCooldownMillis, int longThreshold, int mediumThreshold, int lateThreshold,
+                         Map<ArtifactGrade, Double> gaugeOverrides) {
+        this.plugin = plugin;
+        this.messages = messages;
+        this.chronicleManager = chronicleManager;
+        this.sealMath = sealMath;
+        this.sealPatchValue = sealPatchValue;
+        this.deathIntegrityDecay = deathIntegrityDecay;
+        this.witnessRadius = witnessRadius;
+        this.broadcastCooldownMillis = broadcastCooldownMillis;
+        this.longThreshold = longThreshold;
+        this.mediumThreshold = mediumThreshold;
+        this.lateThreshold = lateThreshold;
+        this.gaugeOverrides.putAll(gaugeOverrides);
+    }
+
+    public void setParadoxManager(ParadoxManager paradoxManager) {
+        this.paradoxManager = paradoxManager;
+    }
+
+    public void load() {
+        plugin.getDataFolder().mkdirs();
+        dataFile = new File(plugin.getDataFolder(), "hunter.yml");
+        if (!dataFile.exists()) {
+            dataConfig = new YamlConfiguration();
+            return;
+        }
+        dataConfig = YamlConfiguration.loadConfiguration(dataFile);
+        profiles.clear();
+        ConfigurationSection huntersSection = dataConfig.getConfigurationSection("hunters");
+        if (huntersSection != null) {
+            for (String key : huntersSection.getKeys(false)) {
+                try {
+                    UUID uuid = UUID.fromString(key);
+                    ConfigurationSection section = huntersSection.getConfigurationSection(key);
+                    if (section == null) {
+                        continue;
+                    }
+                    Map<String, Object> raw = new HashMap<>();
+                    for (String child : section.getKeys(false)) {
+                        raw.put(child, section.get(child));
+                    }
+                    HunterProfile profile = HunterProfile.deserialize(uuid, raw);
+                    if (profile != null) {
+                        profiles.put(uuid, profile);
+                    }
+                } catch (IllegalArgumentException ex) {
+                    plugin.getLogger().warning("Invalid hunter UUID: " + key);
+                }
+            }
+        }
+        testHooks.clear();
+        Object hooksRaw = dataConfig.get("test_hooks");
+        if (hooksRaw instanceof List<?> list) {
+            for (Object entry : list) {
+                if (entry instanceof Map<?, ?> map) {
+                    HunterTestHook hook = HunterTestHook.deserialize(map);
+                    if (hook != null) {
+                        testHooks.put(hook.getId(), hook);
+                    }
+                }
+            }
+        }
+    }
+
+    public void save() {
+        if (dataConfig == null) {
+            dataConfig = new YamlConfiguration();
+        }
+        dataConfig.set("hunters", null);
+        ConfigurationSection huntersSection = dataConfig.createSection("hunters");
+        for (Map.Entry<UUID, HunterProfile> entry : profiles.entrySet()) {
+            ConfigurationSection section = huntersSection.createSection(entry.getKey().toString());
+            Map<String, Object> serialized = entry.getValue().serialize();
+            for (Map.Entry<String, Object> line : serialized.entrySet()) {
+                section.set(line.getKey(), line.getValue());
+            }
+        }
+        List<Map<String, Object>> hooks = new ArrayList<>();
+        for (HunterTestHook hook : testHooks.values()) {
+            hooks.add(hook.serialize());
+        }
+        dataConfig.set("test_hooks", hooks);
+        try {
+            dataConfig.save(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to save hunter.yml: " + e.getMessage());
+        }
+    }
+
+    public HunterProfile getProfile(Player player) {
+        return profiles.computeIfAbsent(player.getUniqueId(), uuid -> new HunterProfile(uuid, player.getName()));
+    }
+
+    public Optional<HunterProfile> findProfile(UUID uuid) {
+        return Optional.ofNullable(profiles.get(uuid));
+    }
+
+    public void handleJoin(Player player) {
+        HunterProfile profile = getProfile(player);
+        profile.setLastKnownName(player.getName());
+        profile.pruneOldReleases(sealMath.getFatigueWindowMillis());
+        for (Artifact artifact : profile.listArtifacts()) {
+            if (artifact.isExpired()) {
+                artifact.setState(ArtifactState.DESTROYED);
+            }
+        }
+        if (profile.isEngraved()) {
+            player.sendMessage(messages.format("hunter.status.header", Map.of(
+                    "integrity", summarizeIntegrity(profile),
+                    "artifacts", String.valueOf(profile.listArtifacts().size())
+            )));
+        }
+    }
+
+    private String summarizeIntegrity(HunterProfile profile) {
+        double avg = 0.0D;
+        int count = 0;
+        for (Artifact artifact : profile.listArtifacts()) {
+            avg += artifact.getIntegrity();
+            count++;
+        }
+        if (count == 0) {
+            return "0";
+        }
+        return String.format(Locale.KOREA, "%.1f%%", avg / count);
+    }
+
+    public boolean acceptQuest(Player player) {
+        HunterProfile profile = getProfile(player);
+        if (profile.isQuestAccepted()) {
+            player.sendMessage(messages.format("hunter.quest.already"));
+            return false;
+        }
+        profile.setQuestAccepted(true);
+        player.sendMessage(messages.format("hunter.quest.accept"));
+        chronicleManager.logEvent(ChronicleEventType.HUNTER_ENGRAVE,
+                messages.format("chronicle.hunter.quest", Map.of("player", player.getName())), List.of(player));
+        save();
+        return true;
+    }
+
+    public boolean engrave(Player player) {
+        HunterProfile profile = getProfile(player);
+        if (!profile.isQuestAccepted()) {
+            player.sendMessage(messages.format("hunter.quest.not_ready"));
+            return false;
+        }
+        if (profile.isEngraved()) {
+            player.sendMessage(messages.format("hunter.quest.already_hunter"));
+            return false;
+        }
+        profile.setEngraved(true);
+        player.sendMessage(messages.format("hunter.quest.complete"));
+        chronicleManager.logEvent(ChronicleEventType.HUNTER_ENGRAVE,
+                messages.format("chronicle.hunter.engraved", Map.of("player", player.getName())), List.of(player));
+        plugin.broadcast(messages.format("broadcast.hunter_engraved", Map.of("player", player.getName())));
+        save();
+        return true;
+    }
+
+    public Artifact craftArtifact(Player player, ArtifactType type, ArtifactOrigin origin, ArtifactGrade grade,
+                                   String name, List<ArtifactAbility> abilities, boolean borrowed, long expirySeconds) {
+        HunterProfile profile = getProfile(player);
+        if (!profile.isEngraved()) {
+            player.sendMessage(messages.format("hunter.error.not_hunter"));
+            return null;
+        }
+        UUID id = UUID.randomUUID();
+        Artifact artifact = new Artifact(id, name, type, origin, grade);
+        double gaugeGain = gaugeOverrides.getOrDefault(grade, grade.getDefaultGaugeGain());
+        if (abilities == null || abilities.isEmpty()) {
+            artifact.addAbility(new ArtifactAbility("surge", messages.format("hunter.default_ability"),
+                    messages.format("hunter.default_ability_desc", Map.of("name", name)), gaugeGain, 20, List.of("burst")));
+        } else {
+            for (ArtifactAbility ability : abilities) {
+                artifact.addAbility(ability);
+            }
+        }
+        if (borrowed) {
+            artifact.setBorrowedFrom(player.getUniqueId());
+        }
+        if (expirySeconds > 0) {
+            artifact.setExpiryTimestamp(Instant.now().getEpochSecond() + expirySeconds);
+        }
+        profile.addArtifact(artifact);
+        updateProgress(profile);
+        chronicleManager.logEvent(ChronicleEventType.HUNTER_ARTIFACT,
+                messages.format("chronicle.hunter.artifact", Map.of(
+                        "player", player.getName(),
+                        "name", name,
+                        "origin", origin.name()
+                )), List.of(player));
+        player.sendMessage(messages.format("hunter.artifact.crafted", Map.of(
+                "name", name,
+                "grade", grade.name(),
+                "type", type.name()
+        )));
+        save();
+        return artifact;
+    }
+
+    public UseResult useAbility(Player player, Artifact artifact, ArtifactAbility ability) {
+        HunterProfile profile = getProfile(player);
+        if (!profile.isEngraved()) {
+            player.sendMessage(messages.format("hunter.error.not_hunter"));
+            return UseResult.error();
+        }
+        if (artifact.getState() == ArtifactState.BROKEN) {
+            player.sendMessage(messages.format("hunter.error.broken"));
+            return UseResult.error();
+        }
+        double before = artifact.getIntegrity();
+        double gain = ability.getGaugeGain();
+        double after = Math.min(100.0D, before + gain);
+        artifact.setIntegrity(after);
+        artifact.setState(sealMath.evaluateState(after, artifact.getState()));
+        double fatigueModifier = computeFatigueModifier(profile);
+        double chance = sealMath.computeChance(after, fatigueModifier);
+        double roll = random.nextDouble();
+        boolean release = roll <= chance;
+        SealLogEntry entry = new SealLogEntry(Instant.now(), before, release ? 100.0D : after,
+                "ABILITY:" + ability.getKey(), roll, release);
+        artifact.addHistory(entry);
+        if (release) {
+            handleRelease(player, profile, artifact, chance, roll, entry);
+        }
+        save();
+        return new UseResult(after, chance, roll, release, fatigueModifier);
+    }
+
+    private void handleRelease(Player player, HunterProfile profile, Artifact artifact, double chance, double roll, SealLogEntry entry) {
+        artifact.setState(ArtifactState.BROKEN);
+        artifact.incrementReleaseCount();
+        artifact.setLastRelease(System.currentTimeMillis());
+        profile.recordRelease(System.currentTimeMillis());
+        updateProgress(profile);
+        Collection<Player> witnesses = collectWitnesses(player.getLocation());
+        if (witnesses.isEmpty()) {
+            witnesses = List.of(player);
+        }
+        for (Player witness : witnesses) {
+            witness.addScoreboardTag("hunter_witness");
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastBroadcast >= broadcastCooldownMillis) {
+            plugin.broadcast(messages.format("broadcast.hunter_release", Map.of(
+                    "player", player.getName(),
+                    "name", artifact.getName(),
+                    "world", player.getWorld().getName()
+            )));
+            lastBroadcast = now;
+        }
+        if (artifact.isPlayerLore()) {
+            chronicleManager.logEvent(ChronicleEventType.HUNTER_BURNED,
+                    messages.format("chronicle.hunter.burned", Map.of("player", player.getName())), witnesses);
+        } else {
+            chronicleManager.logEvent(ChronicleEventType.HUNTER_RELEASE,
+                    messages.format("chronicle.hunter.release", Map.of(
+                            "player", player.getName(),
+                            "artifact", artifact.getName()
+                    )), witnesses);
+        }
+        Bukkit.getPluginManager().callEvent(new HunterReleaseEvent(player, artifact, chance, roll, entry));
+    }
+
+    private Collection<Player> collectWitnesses(Location location) {
+        List<Player> witnesses = new ArrayList<>();
+        World world = location.getWorld();
+        if (world == null) {
+            return witnesses;
+        }
+        double squared = witnessRadius * witnessRadius;
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (!player.getWorld().equals(world)) {
+                continue;
+            }
+            if (player.getLocation().distanceSquared(location) <= squared) {
+                witnesses.add(player);
+            }
+        }
+        return witnesses;
+    }
+
+    private double computeFatigueModifier(HunterProfile profile) {
+        profile.pruneOldReleases(sealMath.getFatigueWindowMillis());
+        int count = profile.getRecentReleases().size();
+        double modifier = 1.1 - 0.1 * count;
+        if (count == 0) {
+            modifier = 1.15;
+        }
+        return sealMath.clampFatigue(modifier);
+    }
+
+    private void updateProgress(HunterProfile profile) {
+        int mythic = profile.countMythicArtifacts();
+        profile.setParadoxProgress(mythic);
+        HunterOmenStage stage = HunterOmenStage.CALM;
+        if (mythic >= lateThreshold) {
+            stage = HunterOmenStage.LATE;
+        } else if (mythic >= mediumThreshold) {
+            stage = HunterOmenStage.MEDIUM;
+        } else if (mythic >= longThreshold) {
+            stage = HunterOmenStage.LONG;
+        }
+        profile.setOmenStage(stage);
+    }
+
+    public double applySealPatch(Player player, Artifact artifact, double amount) {
+        if (artifact.getState() == ArtifactState.BROKEN) {
+            player.sendMessage(messages.format("hunter.error.patch_broken"));
+            return artifact.getIntegrity();
+        }
+        double before = artifact.getIntegrity();
+        double after = Math.max(0.0D, before - amount);
+        artifact.setIntegrity(after);
+        artifact.setState(sealMath.evaluateState(after, artifact.getState()));
+        artifact.addHistory(new SealLogEntry(Instant.now(), before, after, "PATCH", 0.0D, false));
+        save();
+        return after;
+    }
+
+    public double applyDefaultPatch(Player player, Artifact artifact) {
+        return applySealPatch(player, artifact, sealPatchValue);
+    }
+
+    public boolean rebindArtifact(Player player, Artifact artifact) {
+        if (artifact.getState() != ArtifactState.BROKEN) {
+            player.sendMessage(messages.format("hunter.error.not_broken"));
+            return false;
+        }
+        artifact.setState(ArtifactState.SEALED);
+        artifact.setIntegrity(0.0D);
+        artifact.addHistory(new SealLogEntry(Instant.now(), 100.0D, 0.0D, "REBIND", 0.0D, false));
+        player.sendMessage(messages.format("hunter.artifact.resealed", Map.of("name", artifact.getName())));
+        save();
+        return true;
+    }
+
+    public void handleDeath(Player player) {
+        HunterProfile profile = profiles.get(player.getUniqueId());
+        if (profile == null) {
+            return;
+        }
+        boolean modified = false;
+        for (Artifact artifact : profile.listArtifacts()) {
+            double before = artifact.getIntegrity();
+            if (artifact.isPlayerLore()) {
+                artifact.setState(ArtifactState.DESTROYED);
+                artifact.setIntegrity(0.0D);
+                modified = true;
+                continue;
+            }
+            double after = Math.max(0.0D, before - deathIntegrityDecay);
+            artifact.setIntegrity(after);
+            artifact.setState(sealMath.evaluateState(after, artifact.getState()));
+            artifact.addHistory(new SealLogEntry(Instant.now(), before, after, "DEATH", 0.0D, false));
+            if (after != before) {
+                modified = true;
+            }
+        }
+        if (modified) {
+            player.sendMessage(messages.format("hunter.death.penalty"));
+            save();
+        }
+    }
+
+    public boolean forceRelease(Player target, Artifact artifact) {
+        if (artifact.getState() == ArtifactState.BROKEN) {
+            return false;
+        }
+        SealLogEntry entry = new SealLogEntry(Instant.now(), artifact.getIntegrity(), 100.0D, "FORCE", 0.0D, true);
+        artifact.addHistory(entry);
+        handleRelease(target, getProfile(target), artifact, 1.0D, 0.0D, entry);
+        save();
+        return true;
+    }
+
+    public List<String> describeProfile(HunterProfile profile) {
+        List<String> lines = new ArrayList<>();
+        lines.add(messages.format("hunter.status.summary", Map.of(
+                "name", profile.getLastKnownName(),
+                "engraved", profile.isEngraved() ? messages.format("hunter.status.engraved") : messages.format("hunter.status.not_engraved"),
+                "omen", profile.getOmenStage().name(),
+                "paradox", String.valueOf(profile.getParadoxProgress())
+        )));
+        for (Artifact artifact : profile.listArtifacts()) {
+            lines.add(messages.format("hunter.status.artifact", Map.of(
+                    "name", artifact.getName(),
+                    "grade", artifact.getGrade().name(),
+                    "state", artifact.getState().name(),
+                    "integrity", String.format(Locale.KOREA, "%.1f%%", artifact.getIntegrity())
+            )));
+            for (ArtifactAbility ability : artifact.getAbilities()) {
+                lines.add(messages.format("hunter.status.ability", Map.of(
+                        "ability", ability.getName(),
+                        "key", ability.getKey(),
+                        "gauge", String.format(Locale.KOREA, "%.1f", ability.getGaugeGain()),
+                        "cooldown", String.valueOf(ability.getCooldownSeconds())
+                )));
+            }
+        }
+        return lines;
+    }
+
+    public Optional<Artifact> findArtifact(HunterProfile profile, String query) {
+        if (profile == null || query == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(profile.findArtifactByName(query));
+    }
+
+    public HunterTestHook createTestHook(String name, Map<String, Object> params, String creator) {
+        HunterTestHook hook = new HunterTestHook(UUID.randomUUID(), name, params, creator, Instant.now());
+        testHooks.put(hook.getId(), hook);
+        save();
+        return hook;
+    }
+
+    public List<HunterTestHook> listTestHooks() {
+        return List.copyOf(testHooks.values());
+    }
+
+    public void removeTestHook(UUID id) {
+        testHooks.remove(id);
+        save();
+    }
+
+    public ParadoxManager getParadoxManager() {
+        return paradoxManager;
+    }
+
+    public void handleParadoxSuccess(ParadoxManager.ParadoxRitual ritual, HunterProfile profile) {
+        Player player = Bukkit.getPlayer(ritual.hunterId());
+        if (player != null) {
+            player.sendMessage(messages.format("hunter.paradox.success"));
+        }
+        plugin.broadcast(messages.format("broadcast.hunter_paradox_success", Map.of("player", ritual.hunterName())));
+        chronicleManager.logEvent(ChronicleEventType.HUNTER_RESET,
+                messages.format("chronicle.hunter.reset_success", Map.of("player", ritual.hunterName())),
+                new ArrayList<>(Bukkit.getOnlinePlayers()));
+        // Reset hunter ecosystem but preserve chronicles.
+        for (HunterProfile other : profiles.values()) {
+            other.setQuestAccepted(false);
+            other.setEngraved(false);
+            other.setParadoxProgress(0);
+            for (Artifact artifact : other.listArtifacts()) {
+                artifact.setState(ArtifactState.DESTROYED);
+            }
+        }
+        save();
+    }
+
+    public void handleParadoxFailure(ParadoxManager.ParadoxRitual ritual, HunterProfile profile, double failureScale) {
+        Player player = Bukkit.getPlayer(ritual.hunterId());
+        if (player != null) {
+            player.sendMessage(messages.format("hunter.paradox.failure", Map.of("scale", String.format(Locale.KOREA, "%.1f", failureScale))));
+        }
+        plugin.broadcast(messages.format("broadcast.hunter_paradox_failure", Map.of("player", ritual.hunterName())));
+        chronicleManager.logEvent(ChronicleEventType.HUNTER_RESET,
+                messages.format("chronicle.hunter.reset_failure", Map.of("player", ritual.hunterName())),
+                new ArrayList<>(Bukkit.getOnlinePlayers()));
+        profile.setOmenStage(profile.getOmenStage().next());
+        save();
+    }
+
+    public void shutdown() {
+        if (paradoxManager != null) {
+            paradoxManager.shutdown();
+        }
+    }
+
+    public record UseResult(double integrity, double chance, double roll, boolean release, double fatigue) {
+        public static UseResult error() {
+            return new UseResult(-1, 0, 0, false, 1.0);
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/ParadoxManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/ParadoxManager.java
@@ -1,0 +1,116 @@
+package me.j17e4eo.mythof5.hunter;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.chronicle.ChronicleEventType;
+import me.j17e4eo.mythof5.chronicle.ChronicleManager;
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.hunter.data.HunterProfile;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Handles paradox dokkaebi summons and reset rituals.
+ */
+public class ParadoxManager {
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private final ChronicleManager chronicleManager;
+    private final HunterManager hunterManager;
+    private final long ritualWindowTicks;
+    private final double failureScale;
+    private final Random random = new Random();
+    private ParadoxRitual activeRitual;
+    private BukkitTask ritualTask;
+
+    public ParadoxManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager,
+                          HunterManager hunterManager, long ritualWindowSeconds, double failureScale) {
+        this.plugin = plugin;
+        this.messages = messages;
+        this.chronicleManager = chronicleManager;
+        this.hunterManager = hunterManager;
+        this.ritualWindowTicks = ritualWindowSeconds * 20L;
+        this.failureScale = failureScale;
+    }
+
+    public boolean summonParadox(Player summoner, Location location) {
+        plugin.broadcast(messages.format("broadcast.hunter_paradox_summon", Map.of(
+                "player", summoner.getName(),
+                "world", location.getWorld().getName(),
+                "x", String.format(Locale.KOREA, "%.1f", location.getX()),
+                "y", String.format(Locale.KOREA, "%.1f", location.getY()),
+                "z", String.format(Locale.KOREA, "%.1f", location.getZ())
+        )));
+        return true;
+    }
+
+    public synchronized boolean beginRitual(Player player, HunterProfile profile) {
+        if (activeRitual != null) {
+            player.sendMessage(messages.format("hunter.paradox.busy"));
+            return false;
+        }
+        activeRitual = new ParadoxRitual(player.getUniqueId(), player.getName(), player.getLocation().clone(), Instant.now());
+        plugin.broadcast(messages.format("broadcast.hunter_paradox_ritual", Map.of("player", player.getName())));
+        chronicleManager.logEvent(ChronicleEventType.HUNTER_RESET,
+                messages.format("chronicle.hunter.ritual_started", Map.of("player", player.getName())),
+                new ArrayList<>(Bukkit.getOnlinePlayers()));
+        if (ritualTask != null) {
+            ritualTask.cancel();
+        }
+        ritualTask = plugin.getServer().getScheduler().runTaskLater(plugin, () -> evaluateRitual(profile), ritualWindowTicks);
+        return true;
+    }
+
+    private void evaluateRitual(HunterProfile profile) {
+        ParadoxRitual ritual = this.activeRitual;
+        this.activeRitual = null;
+        this.ritualTask = null;
+        if (ritual == null) {
+            return;
+        }
+        Player player = Bukkit.getPlayer(ritual.hunterId());
+        double mythicCount = profile.countMythicArtifacts();
+        double successChance = Math.min(0.2, 0.05 + 0.03 * Math.max(0, mythicCount - 3));
+        double roll = random.nextDouble();
+        if (player != null) {
+            player.sendMessage(messages.format("hunter.paradox.ritual_roll", Map.of(
+                    "chance", String.format(Locale.KOREA, "%.1f%%", successChance * 100.0),
+                    "roll", String.format(Locale.KOREA, "%.2f", roll)
+            )));
+        }
+        if (roll <= successChance) {
+            hunterManager.handleParadoxSuccess(ritual, profile);
+        } else {
+            hunterManager.handleParadoxFailure(ritual, profile, failureScale);
+        }
+    }
+
+    public synchronized void cancelActive(String reason) {
+        if (ritualTask != null) {
+            ritualTask.cancel();
+            ritualTask = null;
+        }
+        if (activeRitual != null) {
+            Player player = Bukkit.getPlayer(activeRitual.hunterId());
+            if (player != null) {
+                player.sendMessage(messages.format("hunter.paradox.cancelled", Map.of("reason", reason)));
+            }
+        }
+        activeRitual = null;
+    }
+
+    public void shutdown() {
+        cancelActive("shutdown");
+    }
+
+    public record ParadoxRitual(UUID hunterId, String hunterName, Location origin, Instant startedAt) {}
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/command/HunterCommand.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/command/HunterCommand.java
@@ -1,0 +1,470 @@
+package me.j17e4eo.mythof5.hunter.command;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.hunter.HunterManager;
+import me.j17e4eo.mythof5.hunter.ParadoxManager;
+import me.j17e4eo.mythof5.hunter.data.Artifact;
+import me.j17e4eo.mythof5.hunter.data.ArtifactAbility;
+import me.j17e4eo.mythof5.hunter.data.ArtifactGrade;
+import me.j17e4eo.mythof5.hunter.data.ArtifactOrigin;
+import me.j17e4eo.mythof5.hunter.data.ArtifactType;
+import me.j17e4eo.mythof5.hunter.data.HunterProfile;
+import me.j17e4eo.mythof5.hunter.test.HunterTestHook;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Command interface for the hunter route.
+ */
+public class HunterCommand implements CommandExecutor, TabCompleter {
+
+    private static final String ADMIN_PERMISSION = "myth.admin.hunter";
+
+    private final Mythof5 plugin;
+    private final HunterManager hunterManager;
+    private final Messages messages;
+
+    public HunterCommand(Mythof5 plugin, HunterManager hunterManager, Messages messages) {
+        this.plugin = plugin;
+        this.hunterManager = hunterManager;
+        this.messages = messages;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (args.length == 0) {
+            sendUsage(sender, label);
+            return true;
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        switch (sub) {
+            case "quest" -> handleQuest(sender, label, Arrays.copyOfRange(args, 1, args.length));
+            case "status" -> handleStatus(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "craft" -> handleCraft(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "list" -> handleList(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "ability" -> handleAbility(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "patch" -> handlePatch(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "rebind" -> handleRebind(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "paradox" -> handleParadox(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "admin" -> handleAdmin(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "test" -> handleTest(sender, Arrays.copyOfRange(args, 1, args.length));
+            default -> sendUsage(sender, label);
+        }
+        return true;
+    }
+
+    private void sendUsage(CommandSender sender, String label) {
+        for (String line : messages.formatList("commands.hunter.usage", Map.of("label", label))) {
+            sender.sendMessage(line);
+        }
+    }
+
+    private void handleQuest(CommandSender sender, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(messages.format("commands.common.player_only"));
+            return;
+        }
+        if (args.length == 0) {
+            sendUsage(sender, label);
+            return;
+        }
+        String step = args[0].toLowerCase(Locale.ROOT);
+        if (step.equals("accept")) {
+            hunterManager.acceptQuest(player);
+        } else if (step.equals("complete")) {
+            hunterManager.engrave(player);
+        } else {
+            sendUsage(sender, label);
+        }
+    }
+
+    private void handleStatus(CommandSender sender, String[] args) {
+        HunterProfile profile;
+        if (args.length >= 1) {
+            if (!sender.hasPermission(ADMIN_PERMISSION)) {
+                sender.sendMessage(messages.format("commands.common.no_permission"));
+                return;
+            }
+            OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
+            if (target == null || (target.getUniqueId() == null && !target.hasPlayedBefore())) {
+                sender.sendMessage(messages.format("commands.common.player_not_online"));
+                return;
+            }
+            profile = hunterManager.findProfile(target.getUniqueId()).orElse(null);
+            if (profile == null) {
+                sender.sendMessage(messages.format("hunter.error.no_profile"));
+                return;
+            }
+        } else {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage(messages.format("commands.common.player_only"));
+                return;
+            }
+            profile = hunterManager.getProfile(player);
+        }
+        for (String line : hunterManager.describeProfile(profile)) {
+            sender.sendMessage(line);
+        }
+    }
+
+    private void handleList(CommandSender sender, String[] args) {
+        handleStatus(sender, args);
+    }
+
+    private void handleCraft(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(messages.format("commands.common.player_only"));
+            return;
+        }
+        if (args.length < 4) {
+            sender.sendMessage(messages.format("hunter.usage.craft"));
+            return;
+        }
+        ArtifactType type = ArtifactType.fromKey(args[0]);
+        ArtifactOrigin origin = ArtifactOrigin.fromKey(args[1]);
+        ArtifactGrade grade = ArtifactGrade.fromKey(args[2]);
+        String name = String.join(" ", Arrays.copyOfRange(args, 3, args.length));
+        hunterManager.craftArtifact(player, type, origin, grade, name, Collections.emptyList(), false, 0);
+    }
+
+    private void handleAbility(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(messages.format("commands.common.player_only"));
+            return;
+        }
+        if (args.length < 2) {
+            sender.sendMessage(messages.format("hunter.usage.ability"));
+            return;
+        }
+        HunterProfile profile = hunterManager.getProfile(player);
+        Optional<Artifact> artifact = hunterManager.findArtifact(profile, args[0]);
+        if (artifact.isEmpty()) {
+            sender.sendMessage(messages.format("hunter.error.artifact_not_found"));
+            return;
+        }
+        ArtifactAbility ability = artifact.get().getAbility(args[1]);
+        if (ability == null) {
+            sender.sendMessage(messages.format("hunter.error.ability_not_found"));
+            return;
+        }
+        HunterManager.UseResult result = hunterManager.useAbility(player, artifact.get(), ability);
+        if (result.integrity() >= 0) {
+            player.sendMessage(messages.format("hunter.ability.result", Map.of(
+                    "name", artifact.get().getName(),
+                    "ability", ability.getName(),
+                    "integrity", String.format(Locale.KOREA, "%.1f%%", result.integrity()),
+                    "chance", String.format(Locale.KOREA, "%.1f%%", result.chance() * 100.0),
+                    "roll", String.format(Locale.KOREA, "%.2f", result.roll()),
+                    "release", result.release() ? messages.format("hunter.ability.release") : messages.format("hunter.ability.safe")
+            )));
+        }
+    }
+
+    private void handlePatch(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(messages.format("commands.common.player_only"));
+            return;
+        }
+        if (args.length < 1) {
+            sender.sendMessage(messages.format("hunter.usage.patch"));
+            return;
+        }
+        HunterProfile profile = hunterManager.getProfile(player);
+        Optional<Artifact> artifact = hunterManager.findArtifact(profile, args[0]);
+        if (artifact.isEmpty()) {
+            sender.sendMessage(messages.format("hunter.error.artifact_not_found"));
+            return;
+        }
+        double value = hunterManager.applyDefaultPatch(player, artifact.get());
+        player.sendMessage(messages.format("hunter.patch.result", Map.of(
+                "name", artifact.get().getName(),
+                "integrity", String.format(Locale.KOREA, "%.1f%%", value)
+        )));
+    }
+
+    private void handleRebind(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(messages.format("commands.common.player_only"));
+            return;
+        }
+        if (args.length < 1) {
+            sender.sendMessage(messages.format("hunter.usage.rebind"));
+            return;
+        }
+        HunterProfile profile = hunterManager.getProfile(player);
+        Optional<Artifact> artifact = hunterManager.findArtifact(profile, args[0]);
+        if (artifact.isEmpty()) {
+            sender.sendMessage(messages.format("hunter.error.artifact_not_found"));
+            return;
+        }
+        hunterManager.rebindArtifact(player, artifact.get());
+    }
+
+    private void handleParadox(CommandSender sender, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage(messages.format("hunter.usage.paradox"));
+            return;
+        }
+        String action = args[0].toLowerCase(Locale.ROOT);
+        if (action.equals("summon")) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage(messages.format("commands.common.player_only"));
+                return;
+            }
+            if (!sender.hasPermission(ADMIN_PERMISSION)) {
+                sender.sendMessage(messages.format("commands.common.no_permission"));
+                return;
+            }
+            ParadoxManager manager = hunterManager.getParadoxManager();
+            if (manager == null) {
+                sender.sendMessage(messages.format("hunter.error.no_paradox"));
+                return;
+            }
+            manager.summonParadox(player, player.getLocation());
+        } else if (action.equals("offer")) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage(messages.format("commands.common.player_only"));
+                return;
+            }
+            HunterProfile profile = hunterManager.getProfile(player);
+            if (profile.getParadoxProgress() < 5) {
+                player.sendMessage(messages.format("hunter.paradox.require_mythic", Map.of(
+                        "count", String.valueOf(profile.getParadoxProgress())
+                )));
+                return;
+            }
+            ParadoxManager manager = hunterManager.getParadoxManager();
+            if (manager == null) {
+                player.sendMessage(messages.format("hunter.error.no_paradox"));
+                return;
+            }
+            manager.beginRitual(player, profile);
+        } else {
+            sender.sendMessage(messages.format("hunter.usage.paradox"));
+        }
+    }
+
+    private void handleAdmin(CommandSender sender, String[] args) {
+        if (!sender.hasPermission(ADMIN_PERMISSION)) {
+            sender.sendMessage(messages.format("commands.common.no_permission"));
+            return;
+        }
+        if (args.length == 0) {
+            sender.sendMessage(messages.format("hunter.usage.admin"));
+            return;
+        }
+        String action = args[0].toLowerCase(Locale.ROOT);
+        switch (action) {
+            case "give" -> adminGive(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "release" -> adminRelease(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "patch" -> adminPatch(sender, Arrays.copyOfRange(args, 1, args.length));
+            case "reset" -> adminReset(sender, Arrays.copyOfRange(args, 1, args.length));
+            default -> sender.sendMessage(messages.format("hunter.usage.admin"));
+        }
+    }
+
+    private void adminGive(CommandSender sender, String[] args) {
+        if (args.length < 5) {
+            sender.sendMessage(messages.format("hunter.usage.admin_give"));
+            return;
+        }
+        Player target = Bukkit.getPlayerExact(args[0]);
+        if (target == null) {
+            sender.sendMessage(messages.format("commands.common.player_not_online"));
+            return;
+        }
+        ArtifactType type = ArtifactType.fromKey(args[1]);
+        ArtifactOrigin origin = ArtifactOrigin.fromKey(args[2]);
+        ArtifactGrade grade = ArtifactGrade.fromKey(args[3]);
+        String name = String.join(" ", Arrays.copyOfRange(args, 4, args.length));
+        hunterManager.craftArtifact(target, type, origin, grade, name, Collections.emptyList(), false, 0);
+        sender.sendMessage(messages.format("hunter.admin.give", Map.of(
+                "player", target.getName(),
+                "name", name
+        )));
+    }
+
+    private void adminRelease(CommandSender sender, String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage(messages.format("hunter.usage.admin_release"));
+            return;
+        }
+        Player target = Bukkit.getPlayerExact(args[0]);
+        if (target == null) {
+            sender.sendMessage(messages.format("commands.common.player_not_online"));
+            return;
+        }
+        HunterProfile profile = hunterManager.getProfile(target);
+        Optional<Artifact> artifact = hunterManager.findArtifact(profile, args[1]);
+        if (artifact.isEmpty()) {
+            sender.sendMessage(messages.format("hunter.error.artifact_not_found"));
+            return;
+        }
+        if (hunterManager.forceRelease(target, artifact.get())) {
+            sender.sendMessage(messages.format("hunter.admin.force_release", Map.of(
+                    "player", target.getName(),
+                    "name", artifact.get().getName()
+            )));
+        }
+    }
+
+    private void adminPatch(CommandSender sender, String[] args) {
+        if (args.length < 3) {
+            sender.sendMessage(messages.format("hunter.usage.admin_patch"));
+            return;
+        }
+        Player target = Bukkit.getPlayerExact(args[0]);
+        if (target == null) {
+            sender.sendMessage(messages.format("commands.common.player_not_online"));
+            return;
+        }
+        HunterProfile profile = hunterManager.getProfile(target);
+        Optional<Artifact> artifact = hunterManager.findArtifact(profile, args[1]);
+        if (artifact.isEmpty()) {
+            sender.sendMessage(messages.format("hunter.error.artifact_not_found"));
+            return;
+        }
+        double value;
+        try {
+            value = Double.parseDouble(args[2]);
+        } catch (NumberFormatException ex) {
+            sender.sendMessage(messages.format("hunter.error.invalid_number"));
+            return;
+        }
+        double result = hunterManager.applySealPatch(target, artifact.get(), value);
+        sender.sendMessage(messages.format("hunter.admin.patch", Map.of(
+                "player", target.getName(),
+                "name", artifact.get().getName(),
+                "integrity", String.format(Locale.KOREA, "%.1f%%", result)
+        )));
+    }
+
+    private void adminReset(CommandSender sender, String[] args) {
+        if (args.length < 1) {
+            sender.sendMessage(messages.format("hunter.usage.admin_reset"));
+            return;
+        }
+        OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
+        if (target == null || target.getUniqueId() == null) {
+            sender.sendMessage(messages.format("commands.common.player_not_online"));
+            return;
+        }
+        Optional<HunterProfile> profile = hunterManager.findProfile(target.getUniqueId());
+        if (profile.isEmpty()) {
+            sender.sendMessage(messages.format("hunter.error.no_profile"));
+            return;
+        }
+        profile.get().setQuestAccepted(false);
+        profile.get().setEngraved(false);
+        sender.sendMessage(messages.format("hunter.admin.reset", Map.of("player", target.getName())));
+        hunterManager.save();
+    }
+
+    private void handleTest(CommandSender sender, String[] args) {
+        if (!sender.hasPermission(ADMIN_PERMISSION)) {
+            sender.sendMessage(messages.format("commands.common.no_permission"));
+            return;
+        }
+        if (args.length == 0) {
+            sender.sendMessage(messages.format("hunter.usage.test"));
+            return;
+        }
+        String action = args[0].toLowerCase(Locale.ROOT);
+        switch (action) {
+            case "create" -> {
+                String name = args.length >= 2 ? args[1] : "hook";
+                Map<String, Object> params = new HashMap<>();
+                if (args.length >= 3) {
+                    params.put("note", String.join(" ", Arrays.copyOfRange(args, 2, args.length)));
+                }
+                HunterTestHook hook = hunterManager.createTestHook(name, params, sender.getName());
+                sender.sendMessage(messages.format("hunter.test.created", Map.of("id", hook.getId().toString())));
+            }
+            case "list" -> {
+                List<HunterTestHook> hooks = hunterManager.listTestHooks();
+                if (hooks.isEmpty()) {
+                    sender.sendMessage(messages.format("hunter.test.empty"));
+                } else {
+                    for (HunterTestHook hook : hooks) {
+                        sender.sendMessage(messages.format("hunter.test.entry", Map.of(
+                                "id", hook.getId().toString(),
+                                "name", hook.getName(),
+                                "creator", hook.getCreatedBy()
+                        )));
+                    }
+                }
+            }
+            case "remove" -> {
+                if (args.length < 2) {
+                    sender.sendMessage(messages.format("hunter.usage.test_remove"));
+                    return;
+                }
+                try {
+                    UUID id = UUID.fromString(args[1]);
+                    hunterManager.removeTestHook(id);
+                    sender.sendMessage(messages.format("hunter.test.removed", Map.of("id", id.toString())));
+                } catch (IllegalArgumentException ex) {
+                    sender.sendMessage(messages.format("hunter.error.invalid_uuid"));
+                }
+            }
+            default -> sender.sendMessage(messages.format("hunter.usage.test"));
+        }
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        if (args.length == 1) {
+            return filter(List.of("quest", "status", "craft", "list", "ability", "patch", "rebind", "paradox", "admin", "test"), args[0]);
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        if (sub.equals("quest")) {
+            if (args.length == 2) {
+                return filter(List.of("accept", "complete"), args[1]);
+            }
+        } else if (sub.equals("paradox")) {
+            if (args.length == 2) {
+                return filter(List.of("summon", "offer"), args[1]);
+            }
+        } else if (sub.equals("admin")) {
+            if (args.length == 2) {
+                return filter(List.of("give", "release", "patch", "reset"), args[1]);
+            }
+        } else if (sub.equals("test")) {
+            if (args.length == 2) {
+                return filter(List.of("create", "list", "remove"), args[1]);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private List<String> filter(List<String> options, String current) {
+        if (current == null || current.isEmpty()) {
+            return options;
+        }
+        List<String> filtered = new ArrayList<>();
+        for (String option : options) {
+            if (option.startsWith(current.toLowerCase(Locale.ROOT))) {
+                filtered.add(option);
+            }
+        }
+        return filtered;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/Artifact.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/Artifact.java
@@ -1,0 +1,253 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Represents a hunter artifact with integrity tracking.
+ */
+public class Artifact {
+
+    private final UUID id;
+    private String name;
+    private ArtifactType type;
+    private ArtifactOrigin origin;
+    private ArtifactGrade grade;
+    private double integrity;
+    private ArtifactState state;
+    private final Map<String, ArtifactAbility> abilities = new LinkedHashMap<>();
+    private final List<SealLogEntry> history = new ArrayList<>();
+    private UUID borrowedFrom;
+    private long expiryTimestamp;
+    private int releaseCount;
+    private long lastRelease;
+
+    public Artifact(UUID id, String name, ArtifactType type, ArtifactOrigin origin, ArtifactGrade grade) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.origin = origin;
+        this.grade = grade;
+        this.integrity = 0.0D;
+        this.state = ArtifactState.STABLE;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ArtifactType getType() {
+        return type;
+    }
+
+    public void setType(ArtifactType type) {
+        this.type = type;
+    }
+
+    public ArtifactOrigin getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(ArtifactOrigin origin) {
+        this.origin = origin;
+    }
+
+    public ArtifactGrade getGrade() {
+        return grade;
+    }
+
+    public void setGrade(ArtifactGrade grade) {
+        this.grade = grade;
+    }
+
+    public double getIntegrity() {
+        return integrity;
+    }
+
+    public void setIntegrity(double integrity) {
+        this.integrity = Math.max(0.0D, Math.min(100.0D, integrity));
+        if (state == ArtifactState.BROKEN || state == ArtifactState.DESTROYED) {
+            return;
+        }
+        this.state = ArtifactState.fromIntegrity(this.integrity);
+    }
+
+    public ArtifactState getState() {
+        return state;
+    }
+
+    public void setState(ArtifactState state) {
+        this.state = state;
+    }
+
+    public UUID getBorrowedFrom() {
+        return borrowedFrom;
+    }
+
+    public void setBorrowedFrom(UUID borrowedFrom) {
+        this.borrowedFrom = borrowedFrom;
+    }
+
+    public long getExpiryTimestamp() {
+        return expiryTimestamp;
+    }
+
+    public void setExpiryTimestamp(long expiryTimestamp) {
+        this.expiryTimestamp = expiryTimestamp;
+    }
+
+    public boolean isExpired() {
+        return expiryTimestamp > 0 && Instant.now().getEpochSecond() >= expiryTimestamp;
+    }
+
+    public int getReleaseCount() {
+        return releaseCount;
+    }
+
+    public void incrementReleaseCount() {
+        this.releaseCount++;
+    }
+
+    public long getLastRelease() {
+        return lastRelease;
+    }
+
+    public void setLastRelease(long lastRelease) {
+        this.lastRelease = lastRelease;
+    }
+
+    public void addAbility(ArtifactAbility ability) {
+        abilities.put(ability.getKey(), ability);
+    }
+
+    public ArtifactAbility getAbility(String key) {
+        if (key == null) {
+            return null;
+        }
+        return abilities.get(key.toLowerCase(Locale.ROOT));
+    }
+
+    public List<ArtifactAbility> getAbilities() {
+        return List.copyOf(abilities.values());
+    }
+
+    public void addHistory(SealLogEntry entry) {
+        history.add(entry);
+        if (history.size() > 50) {
+            history.remove(0);
+        }
+    }
+
+    public List<SealLogEntry> getHistory() {
+        return List.copyOf(history);
+    }
+
+    public boolean isPlayerLore() {
+        return origin == ArtifactOrigin.PLAYER_LORE;
+    }
+
+    public boolean isMythic() {
+        return origin == ArtifactOrigin.MYTHIC;
+    }
+
+    public Map<String, Object> serialize() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("name", name);
+        map.put("type", type.name());
+        map.put("origin", origin.name());
+        map.put("grade", grade.name());
+        map.put("integrity", integrity);
+        map.put("state", state.name());
+        map.put("release_count", releaseCount);
+        map.put("last_release", lastRelease);
+        if (borrowedFrom != null) {
+            map.put("borrowed_from", borrowedFrom.toString());
+        }
+        if (expiryTimestamp > 0) {
+            map.put("expiry", expiryTimestamp);
+        }
+        List<Map<String, Object>> abilityList = new ArrayList<>();
+        for (ArtifactAbility ability : abilities.values()) {
+            abilityList.add(ability.serialize());
+        }
+        map.put("abilities", abilityList);
+        List<Map<String, Object>> logs = new ArrayList<>();
+        for (SealLogEntry entry : history) {
+            logs.add(entry.serialize());
+        }
+        map.put("history", logs);
+        return map;
+    }
+
+    public static Artifact deserialize(UUID id, Map<?, ?> raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            Map<String, Object> data = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : raw.entrySet()) {
+                data.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+            String name = String.valueOf(data.getOrDefault("name", "무명 매개체"));
+            ArtifactType type = ArtifactType.fromKey(String.valueOf(data.get("type")));
+            ArtifactOrigin origin = ArtifactOrigin.fromKey(String.valueOf(data.get("origin")));
+            ArtifactGrade grade = ArtifactGrade.fromKey(String.valueOf(data.get("grade")));
+            Artifact artifact = new Artifact(id, name, type, origin, grade);
+            if (data.get("integrity") != null) {
+                artifact.integrity = Double.parseDouble(String.valueOf(data.get("integrity")));
+            }
+            String stateRaw = String.valueOf(data.getOrDefault("state", ArtifactState.STABLE.name()));
+            try {
+                artifact.state = ArtifactState.valueOf(stateRaw);
+            } catch (IllegalArgumentException ex) {
+                artifact.state = ArtifactState.STABLE;
+            }
+            artifact.releaseCount = Integer.parseInt(String.valueOf(data.getOrDefault("release_count", 0)));
+            artifact.lastRelease = Long.parseLong(String.valueOf(data.getOrDefault("last_release", 0)));
+            if (data.get("borrowed_from") != null) {
+                artifact.borrowedFrom = UUID.fromString(String.valueOf(data.get("borrowed_from")));
+            }
+            if (data.get("expiry") != null) {
+                artifact.expiryTimestamp = Long.parseLong(String.valueOf(data.get("expiry")));
+            }
+            Object abilitiesRaw = data.get("abilities");
+            if (abilitiesRaw instanceof List<?> list) {
+                for (Object entry : list) {
+                    if (entry instanceof Map<?, ?> abilityMap) {
+                        ArtifactAbility ability = ArtifactAbility.deserialize(abilityMap);
+                        if (ability != null) {
+                            artifact.addAbility(ability);
+                        }
+                    }
+                }
+            }
+            Object historyRaw = data.get("history");
+            if (historyRaw instanceof List<?> list) {
+                for (Object entry : list) {
+                    if (entry instanceof Map<?, ?> logMap) {
+                        SealLogEntry log = SealLogEntry.deserialize(logMap);
+                        if (log != null) {
+                            artifact.history.add(log);
+                        }
+                    }
+                }
+            }
+            return artifact;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactAbility.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactAbility.java
@@ -1,0 +1,95 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Describes an active ability bound to an artifact.
+ */
+public class ArtifactAbility {
+
+    private final String key;
+    private final String name;
+    private final String description;
+    private final double gaugeGain;
+    private final int cooldownSeconds;
+    private final List<String> tags;
+
+    public ArtifactAbility(String key, String name, String description, double gaugeGain,
+                           int cooldownSeconds, List<String> tags) {
+        this.key = key.toLowerCase(Locale.ROOT);
+        this.name = name;
+        this.description = description;
+        this.gaugeGain = gaugeGain;
+        this.cooldownSeconds = cooldownSeconds;
+        this.tags = tags == null ? new ArrayList<>() : new ArrayList<>(tags);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public double getGaugeGain() {
+        return gaugeGain;
+    }
+
+    public int getCooldownSeconds() {
+        return cooldownSeconds;
+    }
+
+    public List<String> getTags() {
+        return List.copyOf(tags);
+    }
+
+    public Map<String, Object> serialize() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", key);
+        map.put("name", name);
+        map.put("description", description);
+        map.put("gauge", gaugeGain);
+        map.put("cooldown", cooldownSeconds);
+        map.put("tags", new ArrayList<>(tags));
+        return map;
+    }
+
+    public static ArtifactAbility deserialize(Map<?, ?> raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            Map<String, Object> map = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : raw.entrySet()) {
+                map.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+            String key = String.valueOf(map.get("key"));
+            String name = String.valueOf(map.getOrDefault("name", key));
+            String desc = String.valueOf(map.getOrDefault("description", ""));
+            double gauge = Double.parseDouble(String.valueOf(map.getOrDefault("gauge", 7.0)));
+            int cooldown = Integer.parseInt(String.valueOf(map.getOrDefault("cooldown", 20)));
+            List<String> tags = new ArrayList<>();
+            Object rawTags = map.get("tags");
+            if (rawTags instanceof List<?> list) {
+                for (Object entry : list) {
+                    if (entry != null) {
+                        tags.add(entry.toString());
+                    }
+                }
+            }
+            return new ArtifactAbility(key, name, desc, gauge, cooldown, tags);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactGrade.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactGrade.java
@@ -1,0 +1,34 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+import java.util.Locale;
+
+/**
+ * Grade influences baseline gauge gain.
+ */
+public enum ArtifactGrade {
+    C(7.0),
+    B(9.0),
+    A(11.0),
+    S(12.0);
+
+    private final double defaultGaugeGain;
+
+    ArtifactGrade(double defaultGaugeGain) {
+        this.defaultGaugeGain = defaultGaugeGain;
+    }
+
+    public double getDefaultGaugeGain() {
+        return defaultGaugeGain;
+    }
+
+    public static ArtifactGrade fromKey(String key) {
+        if (key == null) {
+            return C;
+        }
+        try {
+            return ArtifactGrade.valueOf(key.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return C;
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactOrigin.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactOrigin.java
@@ -1,0 +1,23 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+import java.util.Locale;
+
+/**
+ * Identifies the source myth for an artifact.
+ */
+public enum ArtifactOrigin {
+    MYTHIC,
+    LEGEND,
+    PLAYER_LORE;
+
+    public static ArtifactOrigin fromKey(String key) {
+        if (key == null) {
+            return LEGEND;
+        }
+        try {
+            return ArtifactOrigin.valueOf(key.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return LEGEND;
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactState.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactState.java
@@ -1,0 +1,26 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+/**
+ * Represents the lifecycle of a sealed artifact.
+ */
+public enum ArtifactState {
+    STABLE,
+    CRITICAL,
+    BROKEN,
+    SEALED,
+    DESTROYED;
+
+    public boolean isOperational() {
+        return this == STABLE || this == CRITICAL || this == SEALED;
+    }
+
+    public static ArtifactState fromIntegrity(double integrity) {
+        if (integrity >= 90.0) {
+            return CRITICAL;
+        }
+        if (integrity <= 0.0) {
+            return STABLE;
+        }
+        return STABLE;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactType.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/ArtifactType.java
@@ -1,0 +1,24 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+import java.util.Locale;
+
+/**
+ * High-level classification for artifacts.
+ */
+public enum ArtifactType {
+    WEAPON,
+    ACCESSORY,
+    TOOL,
+    BORROWED;
+
+    public static ArtifactType fromKey(String key) {
+        if (key == null) {
+            return TOOL;
+        }
+        try {
+            return ArtifactType.valueOf(key.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            return TOOL;
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/HunterOmenStage.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/HunterOmenStage.java
@@ -1,0 +1,20 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+/**
+ * Tracks hunter-specific omen intensities.
+ */
+public enum HunterOmenStage {
+    CALM,
+    LONG,
+    MEDIUM,
+    LATE;
+
+    public HunterOmenStage next() {
+        return switch (this) {
+            case CALM -> LONG;
+            case LONG -> MEDIUM;
+            case MEDIUM -> LATE;
+            case LATE -> LATE;
+        };
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/HunterProfile.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/HunterProfile.java
@@ -1,0 +1,196 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Persistent record for a hunter player.
+ */
+public class HunterProfile {
+
+    private final UUID playerId;
+    private String lastKnownName;
+    private boolean questAccepted;
+    private boolean engraved;
+    private HunterOmenStage omenStage;
+    private int paradoxProgress;
+    private final Map<UUID, Artifact> artifacts = new LinkedHashMap<>();
+    private final List<Long> recentReleases = new ArrayList<>();
+
+    public HunterProfile(UUID playerId, String lastKnownName) {
+        this.playerId = playerId;
+        this.lastKnownName = lastKnownName;
+        this.omenStage = HunterOmenStage.CALM;
+    }
+
+    public UUID getPlayerId() {
+        return playerId;
+    }
+
+    public String getLastKnownName() {
+        return lastKnownName;
+    }
+
+    public void setLastKnownName(String lastKnownName) {
+        this.lastKnownName = lastKnownName;
+    }
+
+    public boolean isQuestAccepted() {
+        return questAccepted;
+    }
+
+    public void setQuestAccepted(boolean questAccepted) {
+        this.questAccepted = questAccepted;
+    }
+
+    public boolean isEngraved() {
+        return engraved;
+    }
+
+    public void setEngraved(boolean engraved) {
+        this.engraved = engraved;
+    }
+
+    public HunterOmenStage getOmenStage() {
+        return omenStage;
+    }
+
+    public void setOmenStage(HunterOmenStage omenStage) {
+        this.omenStage = omenStage;
+    }
+
+    public int getParadoxProgress() {
+        return paradoxProgress;
+    }
+
+    public void setParadoxProgress(int paradoxProgress) {
+        this.paradoxProgress = Math.max(0, paradoxProgress);
+    }
+
+    public Map<UUID, Artifact> getArtifacts() {
+        return Map.copyOf(artifacts);
+    }
+
+    public void addArtifact(Artifact artifact) {
+        artifacts.put(artifact.getId(), artifact);
+    }
+
+    public Artifact removeArtifact(UUID id) {
+        return artifacts.remove(id);
+    }
+
+    public Artifact getArtifact(UUID id) {
+        return artifacts.get(id);
+    }
+
+    public List<Artifact> listArtifacts() {
+        return List.copyOf(artifacts.values());
+    }
+
+    public List<Long> getRecentReleases() {
+        return recentReleases;
+    }
+
+    public void recordRelease(long epochMillis) {
+        recentReleases.add(epochMillis);
+    }
+
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("name", lastKnownName);
+        data.put("quest", questAccepted);
+        data.put("engraved", engraved);
+        data.put("omen", omenStage.name());
+        data.put("paradox", paradoxProgress);
+        Map<String, Object> artifactSection = new LinkedHashMap<>();
+        for (Map.Entry<UUID, Artifact> entry : artifacts.entrySet()) {
+            artifactSection.put(entry.getKey().toString(), entry.getValue().serialize());
+        }
+        data.put("artifacts", artifactSection);
+        data.put("releases", new ArrayList<>(recentReleases));
+        return data;
+    }
+
+    public static HunterProfile deserialize(UUID id, Map<?, ?> raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            Map<String, Object> data = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : raw.entrySet()) {
+                data.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+            String name = String.valueOf(data.getOrDefault("name", "unknown"));
+            HunterProfile profile = new HunterProfile(id, name);
+            profile.questAccepted = Boolean.parseBoolean(String.valueOf(data.getOrDefault("quest", false)));
+            profile.engraved = Boolean.parseBoolean(String.valueOf(data.getOrDefault("engraved", false)));
+            profile.omenStage = HunterOmenStage.valueOf(String.valueOf(data.getOrDefault("omen", HunterOmenStage.CALM.name())));
+            profile.paradoxProgress = Integer.parseInt(String.valueOf(data.getOrDefault("paradox", 0)));
+            Object artifactsRaw = data.get("artifacts");
+            if (artifactsRaw instanceof Map<?, ?> map) {
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    try {
+                        UUID artifactId = UUID.fromString(String.valueOf(entry.getKey()));
+                        if (entry.getValue() instanceof Map<?, ?> value) {
+                            Artifact artifact = Artifact.deserialize(artifactId, value);
+                            if (artifact != null) {
+                                profile.addArtifact(artifact);
+                            }
+                        }
+                    } catch (IllegalArgumentException ignored) {
+                    }
+                }
+            }
+            Object releases = data.get("releases");
+            if (releases instanceof List<?> list) {
+                for (Object entry : list) {
+                    try {
+                        profile.recentReleases.add(Long.parseLong(String.valueOf(entry)));
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+            }
+            return profile;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+
+    public int countMythicArtifacts() {
+        int count = 0;
+        for (Artifact artifact : artifacts.values()) {
+            if (artifact.isMythic()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public Artifact findArtifactByName(String query) {
+        if (query == null) {
+            return null;
+        }
+        String normalized = query.toLowerCase(Locale.ROOT);
+        for (Artifact artifact : artifacts.values()) {
+            if (artifact.getName().toLowerCase(Locale.ROOT).contains(normalized)) {
+                return artifact;
+            }
+        }
+        try {
+            UUID id = UUID.fromString(query);
+            return artifacts.get(id);
+        } catch (IllegalArgumentException ignored) {
+        }
+        return null;
+    }
+
+    public void pruneOldReleases(long thresholdMillis) {
+        long now = Instant.now().toEpochMilli();
+        recentReleases.removeIf(time -> now - time > thresholdMillis);
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/SealLogEntry.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/data/SealLogEntry.java
@@ -1,0 +1,79 @@
+package me.j17e4eo.mythof5.hunter.data;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Historical snapshot of a seal integrity change.
+ */
+public class SealLogEntry {
+
+    private final Instant timestamp;
+    private final double before;
+    private final double after;
+    private final String action;
+    private final double roll;
+    private final boolean release;
+
+    public SealLogEntry(Instant timestamp, double before, double after, String action, double roll, boolean release) {
+        this.timestamp = timestamp;
+        this.before = before;
+        this.after = after;
+        this.action = action;
+        this.roll = roll;
+        this.release = release;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public double getBefore() {
+        return before;
+    }
+
+    public double getAfter() {
+        return after;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public double getRoll() {
+        return roll;
+    }
+
+    public boolean isRelease() {
+        return release;
+    }
+
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("time", timestamp.toString());
+        data.put("before", before);
+        data.put("after", after);
+        data.put("action", action);
+        data.put("roll", roll);
+        data.put("release", release);
+        return data;
+    }
+
+    public static SealLogEntry deserialize(Map<?, ?> raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            Instant time = Instant.parse(String.valueOf(raw.get("time")));
+            double before = Double.parseDouble(String.valueOf(raw.get("before")));
+            double after = Double.parseDouble(String.valueOf(raw.get("after")));
+            String action = String.valueOf(raw.get("action"));
+            double roll = raw.get("roll") != null ? Double.parseDouble(String.valueOf(raw.get("roll"))) : 0.0D;
+            boolean release = Boolean.parseBoolean(String.valueOf(raw.get("release")));
+            return new SealLogEntry(time, before, after, action, roll, release);
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/event/HunterReleaseEvent.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/event/HunterReleaseEvent.java
@@ -1,0 +1,58 @@
+package me.j17e4eo.mythof5.hunter.event;
+
+import me.j17e4eo.mythof5.hunter.data.Artifact;
+import me.j17e4eo.mythof5.hunter.data.SealLogEntry;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a hunter artifact breaks its seal and releases a dokkaebi.
+ */
+public class HunterReleaseEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player hunter;
+    private final Artifact artifact;
+    private final double chance;
+    private final double roll;
+    private final SealLogEntry logEntry;
+
+    public HunterReleaseEvent(Player hunter, Artifact artifact, double chance, double roll, SealLogEntry logEntry) {
+        this.hunter = hunter;
+        this.artifact = artifact;
+        this.chance = chance;
+        this.roll = roll;
+        this.logEntry = logEntry;
+    }
+
+    public Player getHunter() {
+        return hunter;
+    }
+
+    public Artifact getArtifact() {
+        return artifact;
+    }
+
+    public double getChance() {
+        return chance;
+    }
+
+    public double getRoll() {
+        return roll;
+    }
+
+    public SealLogEntry getLogEntry() {
+        return logEntry;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/math/SealMath.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/math/SealMath.java
@@ -1,0 +1,70 @@
+package me.j17e4eo.mythof5.hunter.math;
+
+import me.j17e4eo.mythof5.hunter.data.ArtifactState;
+
+/**
+ * Encapsulates seal integrity math and release probability.
+ */
+public class SealMath {
+
+    private final double lowChance;
+    private final double criticalBase;
+    private final double slope;
+    private final double cap;
+    private final long fatigueWindowMillis;
+    private final double fatigueMin;
+    private final double fatigueMax;
+
+    public SealMath(double lowChance, double criticalBase, double slope, double cap,
+                    long fatigueWindowMillis, double fatigueMin, double fatigueMax) {
+        this.lowChance = lowChance;
+        this.criticalBase = criticalBase;
+        this.slope = slope;
+        this.cap = cap;
+        this.fatigueWindowMillis = fatigueWindowMillis;
+        this.fatigueMin = fatigueMin;
+        this.fatigueMax = fatigueMax;
+    }
+
+    public double computeChance(double integrity, double fatigueModifier) {
+        double base;
+        if (integrity >= 90.0) {
+            base = criticalBase + slope * (integrity - 90.0);
+            base = Math.min(base, cap);
+        } else {
+            base = lowChance;
+        }
+        double result = base * fatigueModifier;
+        if (result < 0.0) {
+            return 0.0;
+        }
+        if (result > 1.0) {
+            return 1.0;
+        }
+        return result;
+    }
+
+    public ArtifactState evaluateState(double integrity, ArtifactState current) {
+        if (current == ArtifactState.BROKEN || current == ArtifactState.DESTROYED) {
+            return current;
+        }
+        if (integrity >= 90.0) {
+            return ArtifactState.CRITICAL;
+        }
+        return ArtifactState.STABLE;
+    }
+
+    public long getFatigueWindowMillis() {
+        return fatigueWindowMillis;
+    }
+
+    public double clampFatigue(double modifier) {
+        if (modifier < fatigueMin) {
+            return fatigueMin;
+        }
+        if (modifier > fatigueMax) {
+            return fatigueMax;
+        }
+        return modifier;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/test/HunterTestHook.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/test/HunterTestHook.java
@@ -1,0 +1,97 @@
+package me.j17e4eo.mythof5.hunter.test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Lightweight container for QA-controlled hunter simulations.
+ */
+public class HunterTestHook {
+
+    private final UUID id;
+    private final String name;
+    private final Map<String, Object> parameters;
+    private final String createdBy;
+    private final Instant createdAt;
+    private boolean active;
+
+    public HunterTestHook(UUID id, String name, Map<String, Object> parameters, String createdBy, Instant createdAt) {
+        this.id = id;
+        this.name = name;
+        this.parameters = parameters == null ? new HashMap<>() : new HashMap<>(parameters);
+        this.createdBy = createdBy;
+        this.createdAt = createdAt;
+        this.active = true;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, Object> getParameters() {
+        return Map.copyOf(parameters);
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public Map<String, Object> serialize() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", id.toString());
+        map.put("name", name);
+        map.put("params", new HashMap<>(parameters));
+        map.put("created_by", createdBy);
+        map.put("created_at", createdAt.toString());
+        map.put("active", active);
+        return map;
+    }
+
+    public static HunterTestHook deserialize(Map<?, ?> raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            Map<String, Object> data = new HashMap<>();
+            for (Map.Entry<?, ?> entry : raw.entrySet()) {
+                data.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+            UUID id = UUID.fromString(String.valueOf(data.get("id")));
+            String name = String.valueOf(data.getOrDefault("name", "hook"));
+            Map<String, Object> params = new HashMap<>();
+            Object rawParams = data.get("params");
+            if (rawParams instanceof Map<?, ?> map) {
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    if (entry.getKey() != null) {
+                        params.put(String.valueOf(entry.getKey()), entry.getValue());
+                    }
+                }
+            }
+            String createdBy = String.valueOf(data.getOrDefault("created_by", "system"));
+            Instant createdAt = Instant.parse(String.valueOf(data.getOrDefault("created_at", Instant.now().toString())));
+            HunterTestHook hook = new HunterTestHook(id, name, params, createdBy, createdAt);
+            hook.active = Boolean.parseBoolean(String.valueOf(data.getOrDefault("active", true)));
+            return hook;
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/mythof5/src/main/resources/config.yml
+++ b/mythof5/src/main/resources/config.yml
@@ -43,3 +43,32 @@ movement:
     enabled: true
     vertical_velocity: 0.9
     forward_multiplier: 0.6
+hunter:
+  release:
+    low: 0.0052
+    base: 0.1835
+    slope: 0.012
+    cap: 0.45
+    fatigue_window_hours: 1.0
+    fatigue_min: 0.7
+    fatigue_max: 1.2
+  gauge:
+    gain:
+      C: 7.0
+      B: 9.0
+      A: 11.0
+      S: 12.0
+  seal:
+    patch_value: 20.0
+    death_decay: 10.0
+  event:
+    witness_radius: 64.0
+    broadcast_cooldown: 600.0
+  omens:
+    thresholds:
+      long: 2
+      medium: 4
+      late: 5
+  paradox:
+    ritual_window: 600
+    failure_scale: 1.5

--- a/mythof5/src/main/resources/messages.yml
+++ b/mythof5/src/main/resources/messages.yml
@@ -54,6 +54,17 @@ commands:
     name_required: "부대 이름을 입력해주세요."
     player_not_online: "해당 플레이어는 온라인이 아닙니다."
     cannot_invite_self: "자기 자신은 초대할 수 없습니다."
+  hunter:
+    usage:
+      - "{label} quest <accept|complete>"
+      - "{label} status [플레이어]"
+      - "{label} craft <종류> <출처> <등급> <이름...>"
+      - "{label} ability <매개체> <능력코드>"
+      - "{label} patch <매개체>"
+      - "{label} rebind <매개체>"
+      - "{label} paradox <summon|offer>"
+      - "{label} admin <subcommand> ..."
+      - "{label} test <subcommand> ..."
 squad:
   already_in_squad: "이미 다른 부대에 소속되어 있습니다."
   name_taken: "이미 존재하는 부대 이름입니다."
@@ -78,6 +89,74 @@ squad:
   status_count: "인원: {count}/{max} (온라인 {online})"
   status_members: "부대원: {members}"
   friendly_fire_blocked: "부대원에게 피해를 줄 수 없습니다."
+hunter:
+  status:
+    header: "[사냥꾼] 봉인 평균 {integrity} · 매개체 {artifacts}개"
+    summary: "• {name} - {engraved} / 전조 {omen} / 봉헌 {paradox}"
+    engraved: "사냥꾼 각인"
+    not_engraved: "각인 전"
+    artifact: "  - {name} ({grade}) [{state}] 봉인 {integrity}"
+    ability: "    · {ability} ({key}) 게이지 {gauge} · 쿨 {cooldown}s"
+  quest:
+    accept: "역설의 도깨비가 내민 사냥꾼 시험을 받아들였다."
+    already: "이미 사냥꾼 시험이 진행 중이다."
+    not_ready: "먼저 역설의 도깨비를 찾아 시험을 받아야 한다."
+    already_hunter: "이미 사냥꾼 각인이 새겨져 있다."
+    complete: "사냥꾼 각인이 새겨지며 다른 길이 봉인되었다."
+  error:
+    not_hunter: "사냥꾼 각인을 지닌 자만 사용할 수 있다."
+    broken: "봉인이 붕괴되어 힘을 다룰 수 없다."
+    not_broken: "해당 봉인은 이미 안정 상태다."
+    artifact_not_found: "해당 봉인 매개체를 찾을 수 없다."
+    ability_not_found: "해당 능력은 매개체에 봉인되어 있지 않다."
+    patch_broken: "붕괴된 매개체에는 봉인지를 사용할 수 없다."
+    no_profile: "기록된 사냥꾼이 없다."
+    invalid_number: "숫자 형식이 올바르지 않다."
+    invalid_uuid: "올바른 ID 형식이 아니다."
+    no_paradox: "역설 의식을 제어할 도구가 아직 준비되지 않았다."
+  default_ability: "봉인된 격류"
+  default_ability_desc: "{name}에 깃든 정기를 순간적으로 분출한다."
+  ability:
+    result: "매개체 {name}의 {ability} 사용 → 봉인 {integrity} · 해방확률 {chance} · 주사위 {roll} → {release}"
+    release: "봉인이 붕괴했다!"
+    safe: "봉인이 간신히 버텼다."
+  patch:
+    result: "{name}의 봉인 게이지가 {integrity}까지 낮아졌다."
+  artifact:
+    crafted: "새로운 봉인 매개체 {name}({grade}/{type})가 손에 쥐어졌다."
+    resealed: "{name}의 봉인이 다시 잠겼다."
+  death:
+    penalty: "죽음의 충격으로 봉인이 흔들렸다."
+  paradox:
+    busy: "이미 다른 봉헌 의식이 진행 중이다."
+    require_mythic: "태초 신화 매개체 {count}/5개로는 봉헌을 시작할 수 없다."
+    ritual_roll: "봉헌 판정: 성공 {chance} · 굴림 {roll}"
+    success: "봉헌이 완수되어 세계가 초기화된다!"
+    failure: "봉헌이 실패하여 역설이 폭주한다! 위협 배수 x{scale}"
+    cancelled: "봉헌이 중단되었다: {reason}"
+  admin:
+    give: "{player}에게 {name}을(를) 부여했다."
+    force_release: "{player}의 {name} 봉인을 강제로 해제했다."
+    patch: "{player}의 {name} 봉인 상태: {integrity}"
+    reset: "{player}의 사냥꾼 진행도를 초기화했다."
+  usage:
+    craft: "사용법: /hunter craft <종류> <출처> <등급> <이름...>"
+    ability: "사용법: /hunter ability <매개체> <능력코드>"
+    patch: "사용법: /hunter patch <매개체>"
+    rebind: "사용법: /hunter rebind <매개체>"
+    paradox: "사용법: /hunter paradox <summon|offer>"
+    admin: "사용법: /hunter admin <give|release|patch|reset> ..."
+    admin_give: "사용법: /hunter admin give <플레이어> <종류> <출처> <등급> <이름...>"
+    admin_release: "사용법: /hunter admin release <플레이어> <매개체>"
+    admin_patch: "사용법: /hunter admin patch <플레이어> <매개체> <값>"
+    admin_reset: "사용법: /hunter admin reset <플레이어>"
+    test: "사용법: /hunter test <create|list|remove> ..."
+    test_remove: "사용법: /hunter test remove <id>"
+  test:
+    created: "테스트 훅이 생성되었다. ID: {id}"
+    empty: "등록된 테스트 훅이 없다."
+    entry: "- {id} · {name} (작성: {creator})"
+    removed: "테스트 훅 {id}을(를) 제거했다."
 broadcast:
   boss_spawn: "[방송] {name}가 나타났다!"
   squad_created: "[방송] {player}가 부대 {squad}을(를) 창설했습니다."
@@ -85,6 +164,12 @@ broadcast:
   squad_left: "[방송] {player}가 부대 {squad}에서 탈퇴했습니다."
   squad_disbanded: "[방송] 부대 {squad}이(가) 해산되었습니다."
   goblin_inherit: "[방송] {player}가 {aspect}의 힘을 계승했다!"
+  hunter_engraved: "[방송] {player}가 사냥꾼 각인을 받아들였다!"
+  hunter_release: "[방송] {player}의 봉인이 붕괴되어 도깨비가 해방되었다!"
+  hunter_paradox_summon: "[방송] {player}가 역설의 도깨비를 불러냈다 — {world} {x} {y} {z}"
+  hunter_paradox_ritual: "[방송] {player}가 역설 봉헌 의식을 시작했다!"
+  hunter_paradox_success: "[방송] {player}가 봉헌을 완수해 세계가 초기화된다!"
+  hunter_paradox_failure: "[방송] {player}의 봉헌이 실패하여 역설이 폭주한다!"
 inherit:
   previous_replaced: "도깨비의 힘이 다른 계승자에게 이전되었습니다."
   broadcast:
@@ -228,6 +313,11 @@ chronicle:
     relic_gain: "작은 설화 하나가 새로이 깃들었도다."
     relic_fusion: "설화가 합쳐져 기묘한 기운이 솟았도다."
     omen: "세상에 전조가 일어났도다."
+    hunter_engrave: "사냥꾼 각인이 어딘가에서 새겨졌도다."
+    hunter_artifact: "사냥꾼의 봉인 매개체 하나가 만들어졌도다."
+    hunter_burned: "연대기가 불타오르는 소식이 들려왔도다."
+    hunter_release: "사냥꾼의 봉인이 깨져 도깨비가 풀려났도다."
+    hunter_reset: "역설 봉헌이 전 서버의 운명을 뒤흔들었도다."
   inherit:
     transfer: "{killer}, {victim}을 꺾고 {aspect}의 힘을 차지하였도다."
     obtain: "{player}, {aspect}의 힘을 얻기 위해 {method}를 이루었도다."
@@ -241,6 +331,15 @@ chronicle:
     use: "{player}, {aspect}의 권능 '{skill}'을 펼쳤도다."
   omen: "{stage}의 전조가 드러났으니, {reason}라 하도다."
   inherit_loss: "{player}, {aspect}과의 인연이 끊어졌도다."
+  hunter:
+    quest: "{player}, 역설의 도깨비가 낸 사냥꾼 시험을 받아들였도다."
+    engraved: "{player}, 사냥꾼 각인을 받아 다른 길을 봉인하였도다."
+    artifact: "{player}, {grade} 등급 {type} '{name}'에 도깨비 정수를 봉인하였도다."
+    burned: "사냥꾼이 설화를 불태워 연대기가 공백을 남겼도다."
+    release: "{player}, '{artifact}'의 봉인을 깨뜨려 도깨비를 불러냈도다."
+    ritual_started: "{player}, 역설 봉헌 의식을 시작하여 세계가 숨을 죽였도다."
+    reset_success: "{player}, 역설 봉헌을 완수하여 세계를 리셋하였도다."
+    reset_failure: "{player}, 역설 봉헌에 실패하여 역설이 폭주하였도다."
 commands.admin:
   usage:
     - "{label} admin spawnboss <엔티티타입> <이름> [hp] [armor] [world] [x y z]"

--- a/mythof5/src/main/resources/plugin.yml
+++ b/mythof5/src/main/resources/plugin.yml
@@ -20,6 +20,10 @@ commands:
     description: Relic overview commands
     usage: /relic <subcommand>
     permission: myth.user.relic
+  hunter:
+    description: Hunter route commands
+    usage: /hunter <subcommand>
+    permission: myth.user.hunter
 permissions:
   myth.admin.*:
     description: Full access to myth admin commands
@@ -31,6 +35,7 @@ permissions:
       myth.admin.inherit: true
       myth.admin.relic: true
       myth.admin.omen: true
+      myth.admin.hunter: true
   myth.admin.spawnboss:
     description: Spawn a dokkaebi boss
     default: op
@@ -48,6 +53,9 @@ permissions:
     default: op
   myth.admin.omen:
     description: Trigger omen stages
+    default: op
+  myth.admin.hunter:
+    description: Configure hunter systems
     default: op
   myth.user.squad.*:
     description: Access to squad commands
@@ -82,4 +90,7 @@ permissions:
     default: true
   myth.user.relic:
     description: Use relic commands
+    default: true
+  myth.user.hunter:
+    description: Use hunter commands
     default: true


### PR DESCRIPTION
## Summary
- implement the hunter route runtime (manager, listener, command, paradox handling, math, and data models)
- register the hunter systems with the main plugin and expose the /hunter command and permissions
- extend messages, chronicle types, and config defaults for hunter mechanics and broadcasts

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cba10454f0832498521175cd063ea0