### PR TITLE
Remove command permission gating and fix admin access

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -38,7 +38,7 @@
 
 ## 분대 시스템
 * `SquadManager`는 YAML에서 분대와 대기 중인 초대를 불러오고, 구성 가능한 최대 인원 제한을 적용하며, 맵 간에 멤버십 및 아군 사격(friendly fire) 메타데이터를 동기화합니다.【F:mythof5/src/main/java/me/j17e4eo/mythof5/squad/SquadManager.java†L41-L400】
-* 플레이어 명령을 통해 분대 생성, 초대, 수락, 탈퇴, 해산, 상태 조회가 가능하며, 권한 검사는 `myth.user.squad.*` 트리에 매핑되어 있습니다.【F:mythof5/src/main/java/me/j17e4eo/mythof5/command/SquadCommand.java†L31-L181】【F:mythof5/src/main/resources/plugin.yml†L10-L79】
+* 플레이어 명령을 통해 분대 생성, 초대, 수락, 탈퇴, 해산, 상태 조회가 가능하며, 분대 명령은 별도의 권한 검사 없이 모든 플레이어에게 개방되어 있습니다.【F:mythof5/src/main/java/me/j17e4eo/mythof5/command/SquadCommand.java†L31-L149】
 * `SquadListener`는 설정에서 PvP를 허용하지 않는 한 분대원 간의 아군 사격을 차단하고, 공격이 무효화되면 공격자에게 메시지를 보냅니다.【F:mythof5/src/main/java/me/j17e4eo/mythof5/listener/SquadListener.java†L21-L44】【F:mythof5/src/main/java/me/j17e4eo/mythof5/Mythof5.java†L75-L76】【F:mythof5/src/main/resources/config.yml†L38-L40】
 
 ## 연대기와 전조
@@ -49,9 +49,9 @@
 * `PlayerListener`는 접속/퇴장/사망 시 보스 바, 계승, 측면 패시브를 동기화하고, 흔적 아이템 획득 및 의식 상호작용을 측면 시스템으로 전달하며, 고블린 화염 드랍을 가로채 변신을 전환합니다.【F:mythof5/src/main/java/me/j17e4eo/mythof5/listener/PlayerListener.java†L48-L108】
 * 이 리스너는 구성 가능한 더블 점프도 구현하여, 생존/어드벤처 플레이어가 지상에 있을 때 비행을 회복하고, 이를 소비해 설정된 수직/전방 속도로 도약하며, 로켓 음향을 재생합니다. 활공/크리에이티브 모드에서는 토글이 억제됩니다.【F:mythof5/src/main/java/me/j17e4eo/mythof5/listener/PlayerListener.java†L110-L200】【F:mythof5/src/main/java/me/j17e4eo/mythof5/Mythof5.java†L239-L253】【F:mythof5/src/main/resources/config.yml†L41-L45】
 
-## 관리 도구와 권한
+## 관리 도구와 접근
 * `/myth admin`은 보스 소환/목록/종료, 계승 강제 변경, 유물 부여 또는 제거, 최근 연대기 항목 출력, 전조 트리거, 밸런스 표 참조 덤프 등의 하위 명령을 제공합니다.【F:mythof5/src/main/java/me/j17e4eo/mythof5/command/MythAdminCommand.java†L64-L425】
-* myth, squad, goblin, relic 기능에 대한 명령 권한은 `plugin.yml`에 선언되어 있어, 운영자가 세밀하게 제어하고 일반 플레이어에게 필요한 접근 권한을 기본으로 부여할 수 있습니다.【F:mythof5/src/main/resources/plugin.yml†L1-L85】
+* myth, squad, goblin, relic, hunter, seal 명령은 `plugin.yml`에 등록된 그대로 제공되며, 실행 시 별도의 권한 검증 없이 모든 플레이어가 하위 명령을 사용할 수 있습니다.【F:mythof5/src/main/resources/plugin.yml†L1-L24】【F:mythof5/src/main/java/me/j17e4eo/mythof5/command/MythAdminCommand.java†L63-L86】【F:mythof5/src/main/java/me/j17e4eo/mythof5/command/SquadCommand.java†L31-L149】【F:mythof5/src/main/java/me/j17e4eo/mythof5/command/GoblinCommand.java†L33-L119】【F:mythof5/src/main/java/me/j17e4eo/mythof5/command/RelicCommand.java†L28-L95】【F:mythof5/src/main/java/me/j17e4eo/mythof5/hunter/command/HunterCommand.java†L49-L119】【F:mythof5/src/main/java/me/j17e4eo/mythof5/hunter/seal/command/SealCommand.java†L36-L135】
 
 ## 밸런스 참고와 메시징
 * `BalanceTable`은 `/myth admin balance`가 빠르게 디자인을 검토할 수 있도록 목표 밸런스 지표 목록을 제공합니다.【F:mythof5/src/main/java/me/j17e4eo/mythof5/balance/BalanceTable.java†L14-L25】

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/command/MythAdminCommand.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/command/MythAdminCommand.java
@@ -87,10 +87,6 @@ public class MythAdminCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleSpawnBoss(CommandSender sender, String label, String[] args) {
-        if (!hasPermission(sender, "myth.admin.spawnboss")) {
-            sender.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 2) {
             sendUsage(sender, label);
             return;
@@ -184,18 +180,10 @@ public class MythAdminCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleBossList(CommandSender sender) {
-        if (!hasPermission(sender, "myth.admin.bosslist")) {
-            sender.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         bossManager.sendBossList(sender);
     }
 
     private void handleEndBoss(CommandSender sender, String label, String[] args) {
-        if (!hasPermission(sender, "myth.admin.endboss")) {
-            sender.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 1) {
             sender.sendMessage(Component.text(messages.format("commands.myth.end_usage", Map.of("label", label)), NamedTextColor.RED));
             return;
@@ -216,10 +204,6 @@ public class MythAdminCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleInherit(CommandSender sender, String[] args) {
-        if (!hasPermission(sender, "myth.admin.inherit")) {
-            sender.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 2) {
             sender.sendMessage(Component.text(messages.format("commands.admin.inherit_usage"), NamedTextColor.RED));
             return;
@@ -245,10 +229,6 @@ public class MythAdminCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleClearInherit(CommandSender sender, String[] args) {
-        if (!hasPermission(sender, "myth.admin.inherit")) {
-            sender.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 1) {
             sender.sendMessage(Component.text(messages.format("commands.admin.clear_usage"), NamedTextColor.RED));
             return;
@@ -265,10 +245,6 @@ public class MythAdminCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleRelic(CommandSender sender, String[] args) {
-        if (!hasPermission(sender, "myth.admin.relic")) {
-            sender.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 3) {
             sender.sendMessage(Component.text(messages.format("commands.admin.relic_usage"), NamedTextColor.RED));
             return;
@@ -325,10 +301,6 @@ public class MythAdminCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleOmen(CommandSender sender, String[] args) {
-        if (!hasPermission(sender, "myth.admin.omen")) {
-            sender.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 1) {
             sender.sendMessage(Component.text(messages.format("commands.admin.omen_usage"), NamedTextColor.RED));
             return;
@@ -352,10 +324,6 @@ public class MythAdminCommand implements CommandExecutor, TabCompleter {
         for (String line : balanceTable.format()) {
             sender.sendMessage(line);
         }
-    }
-
-    private boolean hasPermission(CommandSender sender, String permission) {
-        return sender.hasPermission("myth.admin.*") || sender.hasPermission(permission);
     }
 
     private void sendUsage(CommandSender sender, String label) {

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/command/SquadCommand.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/command/SquadCommand.java
@@ -65,10 +65,6 @@ public class SquadCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleCreate(Player player, String label, String[] args) {
-        if (!hasPermission(player, "myth.user.squad.create")) {
-            player.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 2) {
             player.sendMessage(Component.text(messages.format("commands.squad.create_usage", java.util.Map.of("label", label)), NamedTextColor.RED));
             return;
@@ -82,10 +78,6 @@ public class SquadCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleInvite(Player player, String label, String[] args) {
-        if (!hasPermission(player, "myth.user.squad.invite")) {
-            player.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 2) {
             player.sendMessage(Component.text(messages.format("commands.squad.invite_usage", java.util.Map.of("label", label)), NamedTextColor.RED));
             return;
@@ -103,10 +95,6 @@ public class SquadCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleAccept(Player player, String label, String[] args) {
-        if (!hasPermission(player, "myth.user.squad.accept")) {
-            player.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         if (args.length < 2) {
             player.sendMessage(Component.text(messages.format("commands.squad.accept_usage", java.util.Map.of("label", label)), NamedTextColor.RED));
             return;
@@ -116,31 +104,15 @@ public class SquadCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleLeave(Player player) {
-        if (!hasPermission(player, "myth.user.squad.leave")) {
-            player.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         squadManager.leave(player);
     }
 
     private void handleDisband(Player player) {
-        if (!hasPermission(player, "myth.user.squad.disband")) {
-            player.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         squadManager.disband(player);
     }
 
     private void handleStatus(Player player) {
-        if (!hasPermission(player, "myth.user.squad.status")) {
-            player.sendMessage(Component.text(messages.format("commands.common.no_permission"), NamedTextColor.RED));
-            return;
-        }
         squadManager.sendStatus(player);
-    }
-
-    private boolean hasPermission(Player player, String permission) {
-        return player.hasPermission("myth.user.squad.*") || player.hasPermission(permission);
     }
 
     private void sendUsage(Player player, String label) {

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/command/HunterCommand.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/command/HunterCommand.java
@@ -36,8 +36,6 @@ import java.util.UUID;
  */
 public class HunterCommand implements CommandExecutor, TabCompleter {
 
-    private static final String ADMIN_PERMISSION = "myth.admin.hunter";
-
     private final Mythof5 plugin;
     private final HunterManager hunterManager;
     private final Messages messages;
@@ -99,10 +97,6 @@ public class HunterCommand implements CommandExecutor, TabCompleter {
     private void handleStatus(CommandSender sender, String[] args) {
         HunterProfile profile;
         if (args.length >= 1) {
-            if (!sender.hasPermission(ADMIN_PERMISSION)) {
-                sender.sendMessage(messages.format("commands.common.no_permission"));
-                return;
-            }
             OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
             if (target == null || (target.getUniqueId() == null && !target.hasPlayedBefore())) {
                 sender.sendMessage(messages.format("commands.common.player_not_online"));
@@ -229,10 +223,6 @@ public class HunterCommand implements CommandExecutor, TabCompleter {
                 sender.sendMessage(messages.format("commands.common.player_only"));
                 return;
             }
-            if (!sender.hasPermission(ADMIN_PERMISSION)) {
-                sender.sendMessage(messages.format("commands.common.no_permission"));
-                return;
-            }
             ParadoxManager manager = hunterManager.getParadoxManager();
             if (manager == null) {
                 sender.sendMessage(messages.format("hunter.error.no_paradox"));
@@ -263,10 +253,6 @@ public class HunterCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleAdmin(CommandSender sender, String[] args) {
-        if (!sender.hasPermission(ADMIN_PERMISSION)) {
-            sender.sendMessage(messages.format("commands.common.no_permission"));
-            return;
-        }
         if (args.length == 0) {
             sender.sendMessage(messages.format("hunter.usage.admin"));
             return;
@@ -379,10 +365,6 @@ public class HunterCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleTest(CommandSender sender, String[] args) {
-        if (!sender.hasPermission(ADMIN_PERMISSION)) {
-            sender.sendMessage(messages.format("commands.common.no_permission"));
-            return;
-        }
         if (args.length == 0) {
             sender.sendMessage(messages.format("hunter.usage.test"));
             return;

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/seal/command/SealCommand.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/seal/command/SealCommand.java
@@ -25,8 +25,6 @@ import java.util.UUID;
  */
 public class SealCommand implements CommandExecutor, TabCompleter {
 
-    private static final String ADMIN_PERMISSION = "myth.admin.seal";
-
     private final SealManager sealManager;
     private final Messages messages;
 
@@ -66,10 +64,6 @@ public class SealCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleAdmin(CommandSender sender, String[] args) {
-        if (!sender.hasPermission(ADMIN_PERMISSION)) {
-            sender.sendMessage(messages.format("commands.common.no_permission"));
-            return;
-        }
         if (args.length == 0) {
             sender.sendMessage(messages.format("commands.seal.admin.usage"));
             return;
@@ -124,9 +118,7 @@ public class SealCommand implements CommandExecutor, TabCompleter {
         if (args.length == 1) {
             List<String> list = new ArrayList<>();
             list.add("status");
-            if (sender.hasPermission(ADMIN_PERMISSION)) {
-                list.add("admin");
-            }
+            list.add("admin");
             return partial(list, args[0]);
         }
         if (args.length >= 2 && args[0].equalsIgnoreCase("admin")) {

--- a/mythof5/src/main/resources/plugin.yml
+++ b/mythof5/src/main/resources/plugin.yml
@@ -6,102 +6,19 @@ commands:
   myth:
     description: Myth administration commands
     usage: /myth admin <subcommand>
-    permission: myth.admin.*
   squad:
     description: Squad management commands
     aliases: [sq]
     usage: /squad <subcommand>
-    permission: myth.user.squad.*
   goblin:
     description: Goblin aspect commands
     usage: /goblin <subcommand>
-    permission: myth.user.goblin
   relic:
     description: Relic overview commands
     usage: /relic <subcommand>
-    permission: myth.user.relic
   hunter:
     description: Hunter route commands
     usage: /hunter <subcommand>
-    permission: myth.user.hunter
   seal:
     description: Weapon sealing interface
     usage: /seal
-    permission: myth.user.seal
-permissions:
-  myth.admin.*:
-    description: Full access to myth admin commands
-    default: op
-    children:
-      myth.admin.spawnboss: true
-      myth.admin.bosslist: true
-      myth.admin.endboss: true
-      myth.admin.inherit: true
-      myth.admin.relic: true
-      myth.admin.omen: true
-      myth.admin.hunter: true
-      myth.admin.seal: true
-  myth.admin.spawnboss:
-    description: Spawn a dokkaebi boss
-    default: op
-  myth.admin.bosslist:
-    description: View active bosses
-    default: op
-  myth.admin.endboss:
-    description: Forcefully end a boss
-    default: op
-  myth.admin.inherit:
-    description: Force assign or clear goblin inheritances
-    default: op
-  myth.admin.relic:
-    description: Grant or revoke relics
-    default: op
-  myth.admin.omen:
-    description: Trigger omen stages
-    default: op
-  myth.admin.hunter:
-    description: Configure hunter systems
-    default: op
-  myth.user.squad.*:
-    description: Access to squad commands
-    default: true
-    children:
-      myth.user.squad.create: true
-      myth.user.squad.invite: true
-      myth.user.squad.accept: true
-      myth.user.squad.leave: true
-      myth.user.squad.disband: true
-      myth.user.squad.status: true
-  myth.user.squad.create:
-    description: Create squads
-    default: true
-  myth.user.squad.invite:
-    description: Invite players to squads
-    default: true
-  myth.user.squad.accept:
-    description: Accept squad invitations
-    default: true
-  myth.user.squad.leave:
-    description: Leave squads
-    default: true
-  myth.user.squad.disband:
-    description: Disband squads
-    default: true
-  myth.user.squad.status:
-    description: View squad status
-    default: true
-  myth.user.goblin:
-    description: Use goblin aspect commands
-    default: true
-  myth.user.relic:
-    description: Use relic commands
-    default: true
-  myth.user.hunter:
-    description: Use hunter commands
-    default: true
-  myth.user.seal:
-    description: Use weapon sealing commands
-    default: true
-  myth.admin.seal:
-    description: Manage weapon seal data
-    default: op


### PR DESCRIPTION
## Summary
- remove explicit permission checks from admin, squad, hunter, and seal command handlers so they are always usable
- drop permission requirements from plugin.yml so commands are available without configured nodes
- update GUIDE.md to explain that myth, squad, goblin, relic, hunter, and seal commands now run without permission gating

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cbd189ccb88324b33047a906551091