### PR TITLE
Implement advanced goblin combat and relic meta systems

### DIFF
--- a/mythof5/src/main/java/me/j17e4eo/mythof5/balance/BalanceTable.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/balance/BalanceTable.java
@@ -1,26 +1,136 @@
 package me.j17e4eo.mythof5.balance;
 
-import java.util.LinkedHashMap;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinAspect;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinSkill;
+import me.j17e4eo.mythof5.relic.RelicType;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.StringJoiner;
 
 /**
- * Stores balancing targets for quick reference via commands.
+ * Aggregates combat telemetry for balance analysis. The data can be inspected
+ * via commands or exported as CSV for offline tooling.
  */
 public class BalanceTable {
 
-    private final Map<String, String> metrics = new LinkedHashMap<>();
+    private int hunterWins;
+    private int inheritorWins;
+    private final Map<String, SkillUsage> skillUsage = new HashMap<>();
+    private final Map<String, Integer> relicCounts = new HashMap<>();
 
-    public BalanceTable() {
-        metrics.put("계승자 vs 일반", "승률 70% 이상");
-        metrics.put("계승자 vs 설화 조합팀", "상황에 따라 50% 이하");
-        metrics.put("설화 단독 효과", "소규모 전투 결정적 / 대규모 전투 보조");
-        metrics.put("연대기 기록 정확도", "100% (실시간 검증)");
+    public synchronized void recordBattle(boolean hunterWon) {
+        if (hunterWon) {
+            hunterWins++;
+        } else {
+            inheritorWins++;
+        }
     }
 
-    public List<String> format() {
-        return metrics.entrySet().stream()
-                .map(entry -> "• " + entry.getKey() + " : " + entry.getValue())
-                .toList();
+    public synchronized void recordSkillUsage(GoblinAspect aspect, GoblinSkill skill,
+                                              String upgrade, boolean inheritor) {
+        String key = aspect.getKey() + ":" + skill.getKey();
+        SkillUsage usage = skillUsage.computeIfAbsent(key, ignored -> new SkillUsage(aspect, skill));
+        usage.total++;
+        if (inheritor) {
+            usage.inheritorUses++;
+        } else {
+            usage.sharedUses++;
+        }
+        if (upgrade != null && !upgrade.isBlank()) {
+            usage.upgrades.merge(upgrade.toLowerCase(Locale.ROOT), 1, Integer::sum);
+        }
+    }
+
+    public synchronized void recordRelicEquipped(RelicType type) {
+        relicCounts.merge(type.getKey(), 1, Integer::sum);
+    }
+
+    public synchronized List<String> formatSummary() {
+        List<String> lines = new ArrayList<>();
+        int totalBattles = hunterWins + inheritorWins;
+        double hunterRate = totalBattles > 0 ? (hunterWins * 100.0D / totalBattles) : 0.0D;
+        lines.add(String.format(Locale.KOREA, "[전투] 헌터 승률 %.1f%% (%d승 / %d패)", hunterRate, hunterWins, inheritorWins));
+        lines.add("[전투] 기록된 스킬 사용 " + skillUsage.size() + "종");
+        lines.add("[전투] 수집된 유물 장착 " + relicCounts.values().stream().mapToInt(Integer::intValue).sum() + "회");
+        return lines;
+    }
+
+    public synchronized List<String> buildReport() {
+        List<String> lines = new ArrayList<>(formatSummary());
+        lines.add("---- 스킬 사용 통계 ----");
+        List<SkillUsage> usageList = new ArrayList<>(skillUsage.values());
+        usageList.sort((a, b) -> Integer.compare(b.total, a.total));
+        for (SkillUsage usage : usageList) {
+            StringJoiner joiner = new StringJoiner(", ");
+            for (Map.Entry<String, Integer> entry : usage.upgrades.entrySet()) {
+                joiner.add(entry.getKey() + " x" + entry.getValue());
+            }
+            String upgradesText = joiner.length() > 0 ? joiner.toString() : "강화 선택 없음";
+            lines.add(String.format(Locale.KOREA,
+                    "• %s.%s - 총 %d회 (계승자 %d / 공유 %d) [%s]",
+                    usage.aspect.getKey(), usage.skill.getKey(), usage.total,
+                    usage.inheritorUses, usage.sharedUses, upgradesText));
+        }
+        lines.add("---- 유물 장착률 ----");
+        relicCounts.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .forEach(entry -> lines.add(String.format(Locale.KOREA,
+                        "• %s - %d회",
+                        entry.getKey(), entry.getValue())));
+        return lines;
+    }
+
+    public synchronized File exportCsv(File folder) throws IOException {
+        folder.mkdirs();
+        File file = new File(folder, "balance-report.csv");
+        try (PrintWriter writer = new PrintWriter(new FileWriter(file))) {
+            writer.println("category,key,subkey,value");
+            writer.printf(Locale.ROOT, "battle,wins,hunter,%d%n", hunterWins);
+            writer.printf(Locale.ROOT, "battle,wins,inheritor,%d%n", inheritorWins);
+            for (SkillUsage usage : skillUsage.values()) {
+                String baseKey = usage.aspect.getKey() + ":" + usage.skill.getKey();
+                writer.printf(Locale.ROOT, "skill,%s,total,%d%n", baseKey, usage.total);
+                writer.printf(Locale.ROOT, "skill,%s,inheritor,%d%n", baseKey, usage.inheritorUses);
+                writer.printf(Locale.ROOT, "skill,%s,shared,%d%n", baseKey, usage.sharedUses);
+                for (Map.Entry<String, Integer> entry : usage.upgrades.entrySet()) {
+                    writer.printf(Locale.ROOT, "skill,%s,upgrade_%s,%d%n",
+                            baseKey, entry.getKey(), entry.getValue());
+                }
+            }
+            for (Map.Entry<String, Integer> entry : relicCounts.entrySet()) {
+                writer.printf(Locale.ROOT, "relic,%s,equipped,%d%n", entry.getKey(), entry.getValue());
+            }
+        }
+        return file;
+    }
+
+    public synchronized void reset() {
+        hunterWins = 0;
+        inheritorWins = 0;
+        skillUsage.clear();
+        relicCounts.clear();
+    }
+
+    private static final class SkillUsage {
+        private final GoblinAspect aspect;
+        private final GoblinSkill skill;
+        private int total;
+        private int inheritorUses;
+        private int sharedUses;
+        private final Map<String, Integer> upgrades = new HashMap<>();
+
+        private SkillUsage(GoblinAspect aspect, GoblinSkill skill) {
+            this.aspect = aspect;
+            this.skill = skill;
+        }
     }
 }

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/chronicle/ChronicleEventType.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/chronicle/ChronicleEventType.java
@@ -9,6 +9,7 @@ public enum ChronicleEventType {
     LOSS,
     SHARE,
     SKILL,
+    SKILL_UPGRADE,
     RELIC_GAIN,
     RELIC_FUSION,
     OMEN,

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/command/RelicCommand.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/command/RelicCommand.java
@@ -1,6 +1,7 @@
 package me.j17e4eo.mythof5.command;
 
 import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.relic.LoreFragmentManager;
 import me.j17e4eo.mythof5.relic.RelicFusion;
 import me.j17e4eo.mythof5.relic.RelicManager;
 import me.j17e4eo.mythof5.relic.RelicType;
@@ -19,10 +20,12 @@ public class RelicCommand implements CommandExecutor, TabCompleter {
 
     private final RelicManager relicManager;
     private final Messages messages;
+    private final LoreFragmentManager loreFragmentManager;
 
-    public RelicCommand(RelicManager relicManager, Messages messages) {
+    public RelicCommand(RelicManager relicManager, Messages messages, LoreFragmentManager loreFragmentManager) {
         this.relicManager = relicManager;
         this.messages = messages;
+        this.loreFragmentManager = loreFragmentManager;
     }
 
     @Override
@@ -47,6 +50,14 @@ public class RelicCommand implements CommandExecutor, TabCompleter {
             }
             case "fusions" -> {
                 showFusions(sender);
+                return true;
+            }
+            case "forge" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(messages.format("commands.common.player_only"));
+                    return true;
+                }
+                loreFragmentManager.attemptForge(player);
                 return true;
             }
             default -> {
@@ -92,7 +103,7 @@ public class RelicCommand implements CommandExecutor, TabCompleter {
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         List<String> completions = new ArrayList<>();
         if (args.length == 1) {
-            completions.addAll(List.of("help", "list", "fusions"));
+            completions.addAll(List.of("help", "list", "fusions", "forge"));
         }
         String current = args[args.length - 1].toLowerCase(Locale.ROOT);
         return completions.stream().filter(entry -> entry.toLowerCase(Locale.ROOT).startsWith(current)).toList();

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/command/gui/AdminGuiManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/command/gui/AdminGuiManager.java
@@ -712,7 +712,7 @@ public class AdminGuiManager implements Listener {
 
     private void showBalance(Player player) {
         player.sendMessage(Component.text("==== 균형 지표 ====", NamedTextColor.GOLD));
-        for (String line : balanceTable.format()) {
+        for (String line : balanceTable.formatSummary()) {
             player.sendMessage(Component.text(line, NamedTextColor.GRAY));
         }
     }

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinAspect.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinAspect.java
@@ -1,5 +1,12 @@
 package me.j17e4eo.mythof5.inherit.aspect;
 
+import me.j17e4eo.mythof5.inherit.skill.PassiveTrigger;
+import me.j17e4eo.mythof5.inherit.skill.SkillEnvironmentTag;
+import me.j17e4eo.mythof5.inherit.skill.SkillHitbox;
+import me.j17e4eo.mythof5.inherit.skill.SkillSpec;
+import me.j17e4eo.mythof5.inherit.skill.SkillStatusEffect;
+import me.j17e4eo.mythof5.inherit.skill.SkillStatusType;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -93,66 +100,147 @@ public enum GoblinAspect {
 
     private static List<GoblinSkill> buildPowerSkills() {
         List<GoblinSkill> list = new ArrayList<>();
+        SkillSpec rushStrike = SkillSpec.builder()
+                .baseDamage(10.0D)
+                .range(4.5D)
+                .hitbox(SkillHitbox.CONE)
+                .addStatus(new SkillStatusEffect(SkillStatusType.BLEED, 80, 0))
+                .addEnvironmentTag(SkillEnvironmentTag.BREAK_BLOCKS)
+                .build();
         list.add(new GoblinSkill("rush_strike", "돌진 일격", GoblinSkillCategory.ACTIVE,
                 35, 1.8D, 0.6D,
                 "전방으로 폭발적으로 돌진하여 경로의 적에게 큰 피해를 입힌다.",
-                "돌진 거리가 짧고 피해량이 감소한다."));
+                "돌진 거리가 짧고 피해량이 감소한다.", rushStrike, null));
+
+        PassiveTrigger staggerTrigger = PassiveTrigger.builder()
+                .healthThreshold(0.3D)
+                .cooldownTicks(20 * 35)
+                .addStatus(new SkillStatusEffect(SkillStatusType.SHIELD, 160, 1))
+                .addStatus(new SkillStatusEffect(SkillStatusType.WEAKEN, 120, 0))
+                .messageKey("goblin.passive.stagger_guard")
+                .build();
         list.add(new GoblinSkill("stagger_guard", "경직 저항", GoblinSkillCategory.PASSIVE,
                 0, 1.0D, 0.6D,
                 "강한 의지로 경직에 거의 걸리지 않는다.",
-                "경직 저항이 일부만 부여된다."));
+                "경직 저항이 일부만 부여된다.", null, staggerTrigger));
         return Collections.unmodifiableList(list);
     }
 
     private static List<GoblinSkill> buildSpeedSkills() {
         List<GoblinSkill> list = new ArrayList<>();
+        SkillSpec pursuit = SkillSpec.builder()
+                .baseDamage(4.0D)
+                .range(25.0D)
+                .durationTicks(200)
+                .hitbox(SkillHitbox.SINGLE)
+                .addStatus(new SkillStatusEffect(SkillStatusType.SLOW, 120, 0))
+                .addStatus(new SkillStatusEffect(SkillStatusType.WEAKEN, 160, 0))
+                .build();
         list.add(new GoblinSkill("pursuit_mark", "추격 표식", GoblinSkillCategory.ACTIVE,
                 30, 1.6D, 0.5D,
                 "응시한 적에게 표식을 새겨 위치를 추적하며 본인에게 가속을 부여한다.",
-                "표식 지속 시간이 짧고 가속 효과가 감소한다."));
+                "표식 지속 시간이 짧고 가속 효과가 감소한다.", pursuit, null));
+
+        PassiveTrigger scent = PassiveTrigger.builder()
+                .cooldownTicks(20 * 20)
+                .addStatus(new SkillStatusEffect(SkillStatusType.SLOW, 60, 0))
+                .messageKey("goblin.passive.scent_reader")
+                .build();
         list.add(new GoblinSkill("scent_reader", "기척 감지", GoblinSkillCategory.PASSIVE,
                 0, 1.0D, 0.5D,
                 "주변의 발자취와 기척을 읽어 위치를 파악한다.",
-                "기척 감지 범위와 빈도가 감소한다."));
+                "기척 감지 범위와 빈도가 감소한다.", null, scent));
         return Collections.unmodifiableList(list);
     }
 
     private static List<GoblinSkill> buildMischiefSkills() {
         List<GoblinSkill> list = new ArrayList<>();
+        SkillSpec twist = SkillSpec.builder()
+                .baseDamage(2.0D)
+                .range(9.0D)
+                .durationTicks(160)
+                .hitbox(SkillHitbox.SPHERE)
+                .addStatus(new SkillStatusEffect(SkillStatusType.STUN, 80, 0))
+                .addStatus(new SkillStatusEffect(SkillStatusType.WEAKEN, 100, 0))
+                .addEnvironmentTag(SkillEnvironmentTag.FREEZE_LIQUIDS)
+                .build();
         list.add(new GoblinSkill("vision_twist", "시야 왜곡", GoblinSkillCategory.ACTIVE,
                 40, 1.7D, 0.55D,
                 "주변 적의 시야를 일그러뜨리고 방향 감각을 잃게 한다.",
-                "범위가 좁고 지속 시간이 짧다."));
+                "범위가 좁고 지속 시간이 짧다.", twist, null));
+
+        SkillSpec veil = SkillSpec.builder()
+                .baseDamage(0.0D)
+                .range(14.0D)
+                .durationTicks(120)
+                .hitbox(SkillHitbox.SPHERE)
+                .addStatus(new SkillStatusEffect(SkillStatusType.WEAKEN, 120, 1))
+                .addEnvironmentTag(SkillEnvironmentTag.SUMMON_SUPPORT)
+                .build();
         list.add(new GoblinSkill("veil_break", "은신 탐지", GoblinSkillCategory.UTILITY,
                 25, 1.5D, 0.5D,
                 "주변 은신한 존재를 끌어내어 위치를 드러낸다.",
-                "감지 범위가 줄어들고 빛남 지속 시간이 짧다."));
+                "감지 범위가 줄어들고 빛남 지속 시간이 짧다.", veil, null));
         return Collections.unmodifiableList(list);
     }
 
     private static List<GoblinSkill> buildFlameSkills() {
         List<GoblinSkill> list = new ArrayList<>();
+        SkillSpec boost = SkillSpec.builder()
+                .baseDamage(0.0D)
+                .range(12.0D)
+                .durationTicks(220)
+                .hitbox(SkillHitbox.SPHERE)
+                .addStatus(new SkillStatusEffect(SkillStatusType.BURN, 40, 0))
+                .addEnvironmentTag(SkillEnvironmentTag.IGNITE_BLOCKS)
+                .build();
         list.add(new GoblinSkill("ember_boost", "불씨 강화", GoblinSkillCategory.ACTIVE,
                 32, 1.6D, 0.7D,
                 "주변 아군의 공격과 저항을 함께 끌어올린다.",
-                "버프의 지속 시간과 강도가 줄어든다."));
+                "버프의 지속 시간과 강도가 줄어든다.", boost, null));
+
+        SkillSpec recovery = SkillSpec.builder()
+                .baseDamage(0.0D)
+                .range(8.0D)
+                .durationTicks(160)
+                .hitbox(SkillHitbox.SPHERE)
+                .addStatus(new SkillStatusEffect(SkillStatusType.SHIELD, 140, 0))
+                .addEnvironmentTag(SkillEnvironmentTag.CLEANSING_FIELD)
+                .build();
         list.add(new GoblinSkill("ember_recovery", "단기 회복", GoblinSkillCategory.UTILITY,
                 24, 1.4D, 0.65D,
                 "타오르는 불씨로 짧은 시간 재생과 해제를 부여한다.",
-                "회복량과 지속 시간이 줄어든다."));
+                "회복량과 지속 시간이 줄어든다.", recovery, null));
         return Collections.unmodifiableList(list);
     }
 
     private static List<GoblinSkill> buildForgeSkills() {
         List<GoblinSkill> list = new ArrayList<>();
+        SkillSpec overdrive = SkillSpec.builder()
+                .baseDamage(0.0D)
+                .range(6.0D)
+                .durationTicks(220)
+                .hitbox(SkillHitbox.SINGLE)
+                .addStatus(new SkillStatusEffect(SkillStatusType.BURN, 60, 0))
+                .addEnvironmentTag(SkillEnvironmentTag.SUMMON_SUPPORT)
+                .build();
         list.add(new GoblinSkill("weapon_overdrive", "무기 강화", GoblinSkillCategory.ACTIVE,
                 28, 1.7D, 0.5D,
                 "주 무기를 단기간 폭발적인 성능으로 개량한다.",
-                "강화 수치와 지속 시간이 감소한다."));
+                "강화 수치와 지속 시간이 감소한다.", overdrive, null));
+
+        SkillSpec legendary = SkillSpec.builder()
+                .baseDamage(0.0D)
+                .range(5.5D)
+                .durationTicks(260)
+                .hitbox(SkillHitbox.SINGLE)
+                .addStatus(new SkillStatusEffect(SkillStatusType.SHIELD, 160, 1))
+                .addEnvironmentTag(SkillEnvironmentTag.SUMMON_SUPPORT)
+                .build();
         list.add(new GoblinSkill("legendary_summon", "일시적 전설 무기 소환", GoblinSkillCategory.ACTIVE,
                 60, 1.8D, 0.5D,
                 "전설급 무기를 소환해 잠시 다룬다.",
-                "소환 시간이 줄고 공격 강화가 감소한다."));
+                "소환 시간이 줄고 공격 강화가 감소한다.", legendary, null));
         return Collections.unmodifiableList(list);
     }
 }

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinSkill.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/aspect/GoblinSkill.java
@@ -1,6 +1,10 @@
 package me.j17e4eo.mythof5.inherit.aspect;
 
+import me.j17e4eo.mythof5.inherit.skill.PassiveTrigger;
+import me.j17e4eo.mythof5.inherit.skill.SkillSpec;
+
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Immutable description of a goblin skill. Behaviour is provided by the
@@ -17,11 +21,22 @@ public final class GoblinSkill {
     private final double sharedEffectiveness;
     private final String description;
     private final String sharedDescription;
+    private final SkillSpec spec;
+    private final PassiveTrigger passiveTrigger;
 
     public GoblinSkill(String key, String displayName, GoblinSkillCategory category,
                        int baseCooldownSeconds, double sharedCooldownMultiplier,
                        double sharedEffectiveness, String description,
                        String sharedDescription) {
+        this(key, displayName, category, baseCooldownSeconds, sharedCooldownMultiplier,
+                sharedEffectiveness, description, sharedDescription, null, null);
+    }
+
+    public GoblinSkill(String key, String displayName, GoblinSkillCategory category,
+                       int baseCooldownSeconds, double sharedCooldownMultiplier,
+                       double sharedEffectiveness, String description,
+                       String sharedDescription, SkillSpec spec,
+                       PassiveTrigger passiveTrigger) {
         this.key = key.toLowerCase(Locale.ROOT);
         this.displayName = displayName;
         this.category = category;
@@ -30,6 +45,8 @@ public final class GoblinSkill {
         this.sharedEffectiveness = sharedEffectiveness;
         this.description = description;
         this.sharedDescription = sharedDescription;
+        this.spec = spec;
+        this.passiveTrigger = passiveTrigger;
     }
 
     public String getKey() {
@@ -69,5 +86,13 @@ public final class GoblinSkill {
             return baseCooldownSeconds;
         }
         return (int) Math.ceil(baseCooldownSeconds * sharedCooldownMultiplier);
+    }
+
+    public Optional<SkillSpec> getSpec() {
+        return Optional.ofNullable(spec);
+    }
+
+    public Optional<PassiveTrigger> getPassiveTrigger() {
+        return Optional.ofNullable(passiveTrigger);
     }
 }

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/PassiveTrigger.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/PassiveTrigger.java
@@ -1,0 +1,76 @@
+package me.j17e4eo.mythof5.inherit.skill;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Conditional trigger metadata for passive skills.
+ */
+public final class PassiveTrigger {
+
+    private final double healthThreshold;
+    private final int cooldownTicks;
+    private final List<SkillStatusEffect> statuses;
+    private final String messageKey;
+
+    private PassiveTrigger(Builder builder) {
+        this.healthThreshold = builder.healthThreshold;
+        this.cooldownTicks = builder.cooldownTicks;
+        this.statuses = List.copyOf(builder.statuses);
+        this.messageKey = builder.messageKey;
+    }
+
+    public double getHealthThreshold() {
+        return healthThreshold;
+    }
+
+    public int getCooldownTicks() {
+        return cooldownTicks;
+    }
+
+    public List<SkillStatusEffect> getStatuses() {
+        return statuses;
+    }
+
+    public String getMessageKey() {
+        return messageKey;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private double healthThreshold = 0.0D;
+        private int cooldownTicks = 200;
+        private final List<SkillStatusEffect> statuses = new ArrayList<>();
+        private String messageKey = "";
+
+        private Builder() {
+        }
+
+        public Builder healthThreshold(double value) {
+            this.healthThreshold = value;
+            return this;
+        }
+
+        public Builder cooldownTicks(int ticks) {
+            this.cooldownTicks = ticks;
+            return this;
+        }
+
+        public Builder addStatus(SkillStatusEffect effect) {
+            this.statuses.add(effect);
+            return this;
+        }
+
+        public Builder messageKey(String key) {
+            this.messageKey = key;
+            return this;
+        }
+
+        public PassiveTrigger build() {
+            return new PassiveTrigger(this);
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillEnvironmentTag.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillEnvironmentTag.java
@@ -1,0 +1,12 @@
+package me.j17e4eo.mythof5.inherit.skill;
+
+/**
+ * Qualifiers for how a skill interacts with the surrounding terrain.
+ */
+public enum SkillEnvironmentTag {
+    BREAK_BLOCKS,
+    IGNITE_BLOCKS,
+    FREEZE_LIQUIDS,
+    SUMMON_SUPPORT,
+    CLEANSING_FIELD
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillHitbox.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillHitbox.java
@@ -1,0 +1,15 @@
+package me.j17e4eo.mythof5.inherit.skill;
+
+/**
+ * Describes the general shape of a goblin skill hitbox.
+ */
+public enum SkillHitbox {
+    /** A spherical area around the caster. */
+    SPHERE,
+    /** A conical area projected from the caster's facing direction. */
+    CONE,
+    /** A line projected forward from the caster. */
+    LINE,
+    /** Applies only to the primary target. */
+    SINGLE
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillSpec.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillSpec.java
@@ -1,0 +1,103 @@
+package me.j17e4eo.mythof5.inherit.skill;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Declarative metadata that accompanies a goblin skill. It is used to drive
+ * combat resolution, status effect application and visual cues.
+ */
+public final class SkillSpec {
+
+    private final double baseDamage;
+    private final double range;
+    private final int durationTicks;
+    private final SkillHitbox hitbox;
+    private final List<SkillStatusEffect> statuses;
+    private final Set<SkillEnvironmentTag> environmentTags;
+
+    private SkillSpec(Builder builder) {
+        this.baseDamage = builder.baseDamage;
+        this.range = builder.range;
+        this.durationTicks = builder.durationTicks;
+        this.hitbox = builder.hitbox;
+        this.statuses = List.copyOf(builder.statuses);
+        this.environmentTags = EnumSet.copyOf(builder.environmentTags);
+    }
+
+    public double getBaseDamage() {
+        return baseDamage;
+    }
+
+    public double getRange() {
+        return range;
+    }
+
+    public int getDurationTicks() {
+        return durationTicks;
+    }
+
+    public SkillHitbox getHitbox() {
+        return hitbox;
+    }
+
+    public List<SkillStatusEffect> getStatuses() {
+        return statuses;
+    }
+
+    public Set<SkillEnvironmentTag> getEnvironmentTags() {
+        return environmentTags;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private double baseDamage;
+        private double range = 3.0D;
+        private int durationTicks = 0;
+        private SkillHitbox hitbox = SkillHitbox.SINGLE;
+        private final List<SkillStatusEffect> statuses = new ArrayList<>();
+        private final EnumSet<SkillEnvironmentTag> environmentTags = EnumSet.noneOf(SkillEnvironmentTag.class);
+
+        private Builder() {
+        }
+
+        public Builder baseDamage(double value) {
+            this.baseDamage = value;
+            return this;
+        }
+
+        public Builder range(double value) {
+            this.range = value;
+            return this;
+        }
+
+        public Builder durationTicks(int ticks) {
+            this.durationTicks = ticks;
+            return this;
+        }
+
+        public Builder hitbox(SkillHitbox hitbox) {
+            this.hitbox = hitbox;
+            return this;
+        }
+
+        public Builder addStatus(SkillStatusEffect effect) {
+            this.statuses.add(effect);
+            return this;
+        }
+
+        public Builder addEnvironmentTag(SkillEnvironmentTag tag) {
+            this.environmentTags.add(tag);
+            return this;
+        }
+
+        public SkillSpec build() {
+            return new SkillSpec(this);
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillStatusEffect.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillStatusEffect.java
@@ -1,0 +1,29 @@
+package me.j17e4eo.mythof5.inherit.skill;
+
+/**
+ * A simple descriptor of a status effect applied by a goblin skill.
+ */
+public final class SkillStatusEffect {
+
+    private final SkillStatusType type;
+    private final int durationTicks;
+    private final int amplifier;
+
+    public SkillStatusEffect(SkillStatusType type, int durationTicks, int amplifier) {
+        this.type = type;
+        this.durationTicks = durationTicks;
+        this.amplifier = amplifier;
+    }
+
+    public SkillStatusType getType() {
+        return type;
+    }
+
+    public int getDurationTicks() {
+        return durationTicks;
+    }
+
+    public int getAmplifier() {
+        return amplifier;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillStatusType.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skill/SkillStatusType.java
@@ -1,0 +1,13 @@
+package me.j17e4eo.mythof5.inherit.skill;
+
+/**
+ * Enumerates the custom status effect keywords that goblin skills can apply.
+ */
+public enum SkillStatusType {
+    BLEED,
+    STUN,
+    BURN,
+    SLOW,
+    WEAKEN,
+    SHIELD
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skilltree/SkillTreeManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skilltree/SkillTreeManager.java
@@ -1,0 +1,262 @@
+package me.j17e4eo.mythof5.inherit.skilltree;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.chronicle.ChronicleEventType;
+import me.j17e4eo.mythof5.chronicle.ChronicleManager;
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinAspect;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinSkill;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Tracks upgrade points and selections for goblin skills.
+ */
+public class SkillTreeManager {
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private final ChronicleManager chronicleManager;
+    private final Map<UUID, PlayerSkillData> data = new HashMap<>();
+    private final Map<String, List<SkillUpgrade>> upgrades = new LinkedHashMap<>();
+    private File file;
+    private YamlConfiguration config;
+
+    public SkillTreeManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager) {
+        this.plugin = plugin;
+        this.messages = messages;
+        this.chronicleManager = chronicleManager;
+        registerDefaults();
+    }
+
+    private void registerDefaults() {
+        register("rush_strike", new SkillUpgrade("range", "강화 A: 폭발 돌파", "돌진 각도를 넓히고 피해량을 증가시킨다.", 1),
+                new SkillUpgrade("bleed", "강화 B: 출혈 단검", "중첩되는 출혈을 부여하여 장기전을 유리하게 만든다.", 1));
+        register("pursuit_mark", new SkillUpgrade("sprint", "강화 A: 폭주 추격", "표식이 유지되는 동안 이동 속도 보너스가 크게 증가한다.", 1),
+                new SkillUpgrade("rupture", "강화 B: 약점 노출", "표식이 새겨진 적이 받는 피해가 상승한다.", 1));
+        register("vision_twist", new SkillUpgrade("dread", "강화 A: 공포 왜곡", "시야 왜곡이 적을 짧게 기절시킨다.", 1),
+                new SkillUpgrade("chill", "강화 B: 냉기 분출", "주변 물과 용암을 얼려 임시 장벽을 만든다.", 1));
+        register("veil_break", new SkillUpgrade("flare", "강화 A: 파수꾼의 비명", "은신한 대상이 드러날 때 순간 피해를 입는다.", 1),
+                new SkillUpgrade("mark", "강화 B: 추적자", "드러난 대상에게 추적 표식이 자동 부여된다.", 1));
+        register("ember_boost", new SkillUpgrade("wildfire", "강화 A: 폭발 버프", "버프 범위가 넓어지고 주변 적에게 화상 피해를 입힌다.", 1),
+                new SkillUpgrade("ward", "강화 B: 화염 수호", "강화된 아군에게 잠시 보호막을 부여한다.", 1));
+        register("ember_recovery", new SkillUpgrade("purify", "강화 A: 정화", "추가 상태 이상을 제거하고 재생량이 증가한다.", 1),
+                new SkillUpgrade("ember_wall", "강화 B: 불씨 장막", "회복 범위에 주기적인 화염 장막을 깐다.", 1));
+        register("weapon_overdrive", new SkillUpgrade("forge_heat", "강화 A: 단조 가열", "무기 강화 시간이 증가하고 화염 피해가 추가된다.", 1),
+                new SkillUpgrade("impact", "강화 B: 충격 파동", "강화된 무기가 추가 충격파 피해를 발생시킨다.", 1));
+        register("legendary_summon", new SkillUpgrade("eternal", "강화 A: 지속 신화", "전설 무기의 지속 시간이 늘어나고 치명타가 강화된다.", 1),
+                new SkillUpgrade("eruption", "강화 B: 불꽃 해방", "소환 시 화염 폭발이 일어나 적을 밀쳐낸다.", 1));
+    }
+
+    private void register(String skillKey, SkillUpgrade a, SkillUpgrade b) {
+        List<SkillUpgrade> options = new ArrayList<>();
+        options.add(a);
+        options.add(b);
+        upgrades.put(skillKey.toLowerCase(Locale.ROOT), Collections.unmodifiableList(options));
+    }
+
+    public void load() {
+        plugin.getDataFolder().mkdirs();
+        file = new File(plugin.getDataFolder(), "skills.yml");
+        if (!file.exists()) {
+            config = new YamlConfiguration();
+            return;
+        }
+        config = YamlConfiguration.loadConfiguration(file);
+        data.clear();
+        ConfigurationSection playersSection = config.getConfigurationSection("players");
+        if (playersSection == null) {
+            return;
+        }
+        for (String key : playersSection.getKeys(false)) {
+            try {
+                UUID uuid = UUID.fromString(key);
+                ConfigurationSection section = playersSection.getConfigurationSection(key);
+                if (section == null) {
+                    continue;
+                }
+                int points = section.getInt("points", 0);
+                Map<String, String> selections = new HashMap<>();
+                ConfigurationSection selectSection = section.getConfigurationSection("selections");
+                if (selectSection != null) {
+                    for (String skillKey : selectSection.getKeys(false)) {
+                        selections.put(skillKey, selectSection.getString(skillKey));
+                    }
+                }
+                data.put(uuid, new PlayerSkillData(points, selections));
+            } catch (IllegalArgumentException ex) {
+                plugin.getLogger().warning("Invalid UUID in skills.yml: " + key);
+            }
+        }
+    }
+
+    public void save() {
+        if (config == null) {
+            config = new YamlConfiguration();
+        }
+        config.set("players", null);
+        for (Map.Entry<UUID, PlayerSkillData> entry : data.entrySet()) {
+            String key = entry.getKey().toString();
+            PlayerSkillData profile = entry.getValue();
+            config.set("players." + key + ".points", profile.getPoints());
+            for (Map.Entry<String, String> selection : profile.getSelections().entrySet()) {
+                config.set("players." + key + ".selections." + selection.getKey(), selection.getValue());
+            }
+        }
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to save skills.yml: " + e.getMessage());
+        }
+    }
+
+    public int getAvailablePoints(UUID uuid) {
+        return data.computeIfAbsent(uuid, ignored -> new PlayerSkillData(0, new HashMap<>())).getPoints();
+    }
+
+    public void addPoints(UUID uuid, int amount, String reason) {
+        if (amount <= 0) {
+            return;
+        }
+        PlayerSkillData profile = data.computeIfAbsent(uuid, ignored -> new PlayerSkillData(0, new HashMap<>()));
+        profile.addPoints(amount);
+        save();
+        Player player = Bukkit.getPlayer(uuid);
+        String reasonText = (reason == null || reason.isBlank())
+                ? messages.format("goblin.skilltree.reason.unknown")
+                : reason;
+        if (player != null) {
+            player.sendMessage(messages.format("goblin.skilltree.gain", Map.of(
+                    "points", String.valueOf(amount),
+                    "reason", reasonText
+            )));
+        }
+        chronicleManager.logEvent(ChronicleEventType.SKILL,
+                messages.format("chronicle.skill.point", Map.of(
+                        "player", player != null ? player.getName() : uuid.toString(),
+                        "points", String.valueOf(amount),
+                        "reason", reasonText
+                )), player != null ? List.of(player) : List.of());
+    }
+
+    public Optional<SkillUpgrade> findUpgrade(String skillKey, String upgradeId) {
+        List<SkillUpgrade> options = upgrades.get(skillKey.toLowerCase(Locale.ROOT));
+        if (options == null) {
+            return Optional.empty();
+        }
+        for (SkillUpgrade upgrade : options) {
+            if (upgrade.getId().equalsIgnoreCase(upgradeId)) {
+                return Optional.of(upgrade);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public List<SkillUpgrade> getUpgrades(String skillKey) {
+        return upgrades.getOrDefault(skillKey.toLowerCase(Locale.ROOT), Collections.emptyList());
+    }
+
+    public String getSelectedUpgrade(UUID uuid, String skillKey) {
+        PlayerSkillData profile = data.get(uuid);
+        if (profile == null) {
+            return null;
+        }
+        return profile.getSelections().get(skillKey.toLowerCase(Locale.ROOT));
+    }
+
+    public boolean selectUpgrade(Player player, GoblinSkill skill, SkillUpgrade upgrade) {
+        UUID uuid = player.getUniqueId();
+        PlayerSkillData profile = data.computeIfAbsent(uuid, ignored -> new PlayerSkillData(0, new HashMap<>()));
+        String key = skill.getKey();
+        if (profile.getSelections().containsKey(key)) {
+            player.sendMessage(messages.format("goblin.skilltree.already"));
+            return false;
+        }
+        if (profile.getPoints() < upgrade.getCost()) {
+            player.sendMessage(messages.format("goblin.skilltree.not_enough"));
+            return false;
+        }
+        profile.addPoints(-upgrade.getCost());
+        profile.getSelections().put(key, upgrade.getId());
+        save();
+        chronicleManager.logEvent(ChronicleEventType.SKILL_UPGRADE,
+                messages.format("chronicle.skill.upgrade", Map.of(
+                        "player", player.getName(),
+                        "skill", skill.getDisplayName(),
+                        "upgrade", upgrade.getName()
+                )), List.of(player));
+        player.sendMessage(messages.format("goblin.skilltree.unlocked", Map.of(
+                "skill", skill.getDisplayName(),
+                "upgrade", upgrade.getName()
+        )));
+        return true;
+    }
+
+    public List<String> describeTree(Player player, GoblinAspect aspect) {
+        UUID uuid = player.getUniqueId();
+        PlayerSkillData profile = data.computeIfAbsent(uuid, ignored -> new PlayerSkillData(0, new HashMap<>()));
+        List<String> lines = new ArrayList<>();
+        lines.add(messages.format("goblin.skilltree.header", Map.of(
+                "points", String.valueOf(profile.getPoints()))));
+        for (GoblinSkill skill : aspect.getSkills()) {
+            if (skill.getCategory() == null || skill.getCategory().name().equals("PASSIVE")) {
+                continue;
+            }
+            lines.add(messages.format("goblin.skilltree.skill", Map.of(
+                    "name", skill.getDisplayName(),
+                    "key", skill.getKey())));
+            String selected = profile.getSelections().get(skill.getKey());
+            if (selected != null) {
+                Optional<SkillUpgrade> upgrade = findUpgrade(skill.getKey(), selected);
+                upgrade.ifPresent(value -> lines.add("  - " + value.getName() + " : " + value.getDescription()));
+            } else {
+                lines.add(messages.format("goblin.skilltree.none"));
+                for (SkillUpgrade option : getUpgrades(skill.getKey())) {
+                    lines.add(messages.format("goblin.skilltree.option", Map.of(
+                            "id", option.getId(),
+                            "name", option.getName(),
+                            "desc", option.getDescription(),
+                            "cost", String.valueOf(option.getCost())
+                    )));
+                }
+            }
+        }
+        return lines;
+    }
+
+    private static final class PlayerSkillData {
+        private int points;
+        private final Map<String, String> selections;
+
+        private PlayerSkillData(int points, Map<String, String> selections) {
+            this.points = points;
+            this.selections = selections;
+        }
+
+        private int getPoints() {
+            return points;
+        }
+
+        private Map<String, String> getSelections() {
+            return selections;
+        }
+
+        private void addPoints(int delta) {
+            this.points = Math.max(0, this.points + delta);
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skilltree/SkillUpgrade.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/inherit/skilltree/SkillUpgrade.java
@@ -1,0 +1,35 @@
+package me.j17e4eo.mythof5.inherit.skilltree;
+
+/**
+ * Immutable descriptor of a selectable skill upgrade node.
+ */
+public final class SkillUpgrade {
+
+    private final String id;
+    private final String name;
+    private final String description;
+    private final int cost;
+
+    public SkillUpgrade(String id, String name, String description, int cost) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.cost = cost;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getCost() {
+        return cost;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/meta/MetaEventManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/meta/MetaEventManager.java
@@ -1,0 +1,142 @@
+package me.j17e4eo.mythof5.meta;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.inherit.aspect.GoblinSkill;
+import me.j17e4eo.mythof5.relic.LoreFragmentManager;
+import me.j17e4eo.mythof5.relic.LoreFragmentType;
+import me.j17e4eo.mythof5.relic.RelicType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Drives meta progression events based on repeated chronicle activity.
+ */
+public class MetaEventManager {
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private LoreFragmentManager loreFragmentManager;
+    private final Deque<String> recentSkills = new ArrayDeque<>();
+    private final Map<String, Deque<Long>> fusionHistory = new HashMap<>();
+    private long balanceCollapseExpire;
+    private long loreFractureExpire;
+
+    public MetaEventManager(Mythof5 plugin, Messages messages) {
+        this.plugin = plugin;
+        this.messages = messages;
+    }
+
+    public void setLoreFragmentManager(LoreFragmentManager loreFragmentManager) {
+        this.loreFragmentManager = loreFragmentManager;
+    }
+
+    public void recordSkillUse(Player player, GoblinSkill skill) {
+        if (skill == null) {
+            return;
+        }
+        recentSkills.addLast(skill.getKey());
+        if (recentSkills.size() > 6) {
+            recentSkills.removeFirst();
+        }
+        if (recentSkills.size() < 4) {
+            return;
+        }
+        String key = skill.getKey();
+        int matches = 0;
+        Iterator<String> iterator = recentSkills.descendingIterator();
+        while (iterator.hasNext()) {
+            String entry = iterator.next();
+            if (!entry.equalsIgnoreCase(key)) {
+                break;
+            }
+            matches++;
+            if (matches >= 4) {
+                break;
+            }
+        }
+        if (matches >= 4 && System.currentTimeMillis() > balanceCollapseExpire) {
+            triggerBalanceCollapse(skill);
+        }
+    }
+
+    public void recordRelicFusion(RelicType type) {
+        if (type == null) {
+            return;
+        }
+        Deque<Long> history = fusionHistory.computeIfAbsent(type.getKey(), key -> new ArrayDeque<>());
+        long now = System.currentTimeMillis();
+        history.addLast(now);
+        while (!history.isEmpty() && now - history.peekFirst() > 600_000L) {
+            history.removeFirst();
+        }
+        if (history.size() >= 2 && now > loreFractureExpire) {
+            triggerLoreFracture(type);
+            history.clear();
+        }
+    }
+
+    public void recordRelicGain(RelicType type) {
+        if (type == null) {
+            return;
+        }
+        Deque<Long> history = fusionHistory.get(type.getKey());
+        if (history != null) {
+            history.clear();
+        }
+    }
+
+    public boolean isLoreFractureActive() {
+        return System.currentTimeMillis() < loreFractureExpire;
+    }
+
+    public boolean isBalanceCollapseActive() {
+        return System.currentTimeMillis() < balanceCollapseExpire;
+    }
+
+    private void triggerBalanceCollapse(GoblinSkill skill) {
+        balanceCollapseExpire = System.currentTimeMillis() + 240_000L;
+        Bukkit.broadcast(Component.text(messages.format("events.balance_collapse.start", Map.of(
+                "skill", skill.getDisplayName()
+        )), NamedTextColor.DARK_RED));
+        for (World world : Bukkit.getWorlds()) {
+            for (LivingEntity entity : world.getLivingEntities()) {
+                if (entity instanceof Monster monster) {
+                    monster.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, 200, 0, true, true, true));
+                    monster.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 200, 0, true, true, true));
+                }
+            }
+        }
+    }
+
+    private void triggerLoreFracture(RelicType type) {
+        loreFractureExpire = System.currentTimeMillis() + 300_000L;
+        Bukkit.broadcast(Component.text(messages.format("events.lore_fracture.start", Map.of(
+                "relic", type.getDisplayName()
+        )), NamedTextColor.DARK_PURPLE));
+        if (loreFragmentManager == null) {
+            return;
+        }
+        LoreFragmentType[] fragments = LoreFragmentType.values();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            LoreFragmentType fragmentType = fragments[ThreadLocalRandom.current().nextInt(fragments.length)];
+            ItemStack stack = loreFragmentManager.createFragmentItem(fragmentType);
+            player.getWorld().dropItemNaturally(player.getLocation().add(0, 1, 0), stack).setGlowing(true);
+        }
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/LoreFragmentManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/LoreFragmentManager.java
@@ -1,0 +1,198 @@
+package me.j17e4eo.mythof5.relic;
+
+import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.meta.MetaEventManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Controls the lore fragment drop table and forging logic.
+ */
+public class LoreFragmentManager implements Listener {
+
+    private final Mythof5 plugin;
+    private final Messages messages;
+    private final RelicManager relicManager;
+    private MetaEventManager metaEventManager;
+    private final Random random = new Random();
+    private final NamespacedKey fragmentKey;
+    private final NamespacedKey fragmentTypeKey;
+    private final double dropChance;
+    private final List<LoreFragmentRecipe> recipes = new ArrayList<>();
+
+    public LoreFragmentManager(Mythof5 plugin, Messages messages, RelicManager relicManager) {
+        this.plugin = plugin;
+        this.messages = messages;
+        this.relicManager = relicManager;
+        this.fragmentKey = new NamespacedKey(plugin, "lore_fragment");
+        this.fragmentTypeKey = new NamespacedKey(plugin, "lore_fragment_type");
+        this.dropChance = Math.max(0.0005D, plugin.getConfig().getDouble("relic.fragments.drop_chance", 0.01D));
+        registerRecipes();
+    }
+
+    public void setMetaEventManager(MetaEventManager metaEventManager) {
+        this.metaEventManager = metaEventManager;
+    }
+
+    private void registerRecipes() {
+        recipes.add(new LoreFragmentRecipe(EnumSet.of(LoreFragmentType.EMBER, LoreFragmentType.SHADOW),
+                RelicType.TWILIGHT_CINDERS, "불씨와 그림자가 뒤섞인 이계의 칼날"));
+        recipes.add(new LoreFragmentRecipe(EnumSet.of(LoreFragmentType.TIDE, LoreFragmentType.GALE),
+                RelicType.STORMCALLER_DRUM, "조류와 바람을 다루는 폭풍 북"));
+        recipes.add(new LoreFragmentRecipe(EnumSet.of(LoreFragmentType.STONE, LoreFragmentType.EMBER),
+                RelicType.FORGE_HEART, "대장장이 도깨비의 숨결이 깃든 심장"));
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityDeath(EntityDeathEvent event) {
+        LivingEntity entity = event.getEntity();
+        Player killer = entity.getKiller();
+        if (killer == null || entity instanceof Player) {
+            return;
+        }
+        double effectiveChance = dropChance;
+        if (metaEventManager != null && metaEventManager.isLoreFractureActive()) {
+            effectiveChance *= 3.0D;
+        }
+        if (effectiveChance > 1.0D) {
+            effectiveChance = 1.0D;
+        }
+        if (random.nextDouble() > effectiveChance) {
+            return;
+        }
+        LoreFragmentType type = LoreFragmentType.values()[random.nextInt(LoreFragmentType.values().length)];
+        ItemStack fragment = createFragmentItem(type);
+        entity.getWorld().dropItemNaturally(entity.getLocation().add(0, 0.5, 0), fragment).setGlowing(true);
+        killer.sendMessage(messages.format("relic.fragment.drop", Map.of(
+                "type", type.getDisplayName())));
+    }
+
+    public ItemStack createFragmentItem(LoreFragmentType type) {
+        ItemStack stack = new ItemStack(Material.PRISMARINE_SHARD);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.displayName(Component.text(type.getDisplayName(), type.getColor()));
+            List<Component> lore = new ArrayList<>();
+            lore.add(Component.text(messages.format("relic.fragment.lore"), NamedTextColor.GRAY));
+            meta.lore(lore);
+            PersistentDataContainer container = meta.getPersistentDataContainer();
+            container.set(fragmentKey, PersistentDataType.BYTE, (byte) 1);
+            container.set(fragmentTypeKey, PersistentDataType.STRING, type.getKey());
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    public boolean isFragment(ItemStack itemStack) {
+        if (itemStack == null || itemStack.getType() == Material.AIR) {
+            return false;
+        }
+        ItemMeta meta = itemStack.getItemMeta();
+        return meta != null && meta.getPersistentDataContainer().has(fragmentKey, PersistentDataType.BYTE);
+    }
+
+    public Optional<LoreFragmentType> getFragmentType(ItemStack stack) {
+        if (!isFragment(stack)) {
+            return Optional.empty();
+        }
+        ItemMeta meta = stack.getItemMeta();
+        if (meta == null) {
+            return Optional.empty();
+        }
+        String raw = meta.getPersistentDataContainer().get(fragmentTypeKey, PersistentDataType.STRING);
+        return Optional.ofNullable(LoreFragmentType.fromKey(raw));
+    }
+
+    public boolean attemptForge(Player player) {
+        Map<LoreFragmentType, Integer> counts = player.getInventory().getContents() == null ? Map.of() : countFragments(player);
+        for (LoreFragmentRecipe recipe : recipes) {
+            if (hasIngredients(counts, recipe.getIngredients())) {
+                consumeFragments(player, recipe.getIngredients());
+                relicManager.grantRelic(player, recipe.getResult(), true);
+                broadcastForgeAnnouncement(player, recipe.getResult());
+                player.sendMessage(messages.format("relic.fragment.forge_success", Map.of(
+                        "relic", recipe.getResult().getDisplayName(),
+                        "desc", recipe.getDescription()
+                )));
+                return true;
+            }
+        }
+        player.sendMessage(messages.format("relic.fragment.forge_fail"));
+        return false;
+    }
+
+    private Map<LoreFragmentType, Integer> countFragments(Player player) {
+        Map<LoreFragmentType, Integer> counts = new EnumMap<>(LoreFragmentType.class);
+        for (ItemStack stack : player.getInventory().getContents()) {
+            if (stack == null) {
+                continue;
+            }
+            getFragmentType(stack).ifPresent(type ->
+                    counts.merge(type, stack.getAmount(), Integer::sum));
+        }
+        return counts;
+    }
+
+    private boolean hasIngredients(Map<LoreFragmentType, Integer> counts, Set<LoreFragmentType> required) {
+        for (LoreFragmentType type : required) {
+            if (counts.getOrDefault(type, 0) <= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void consumeFragments(Player player, Set<LoreFragmentType> ingredients) {
+        for (LoreFragmentType type : ingredients) {
+            int remaining = 1;
+            ItemStack[] contents = player.getInventory().getContents();
+            for (int i = 0; i < contents.length && remaining > 0; i++) {
+                ItemStack stack = contents[i];
+                if (stack == null) {
+                    continue;
+                }
+                if (getFragmentType(stack).orElse(null) == type) {
+                    int take = Math.min(remaining, stack.getAmount());
+                    stack.setAmount(stack.getAmount() - take);
+                    if (stack.getAmount() <= 0) {
+                        contents[i] = null;
+                    }
+                    remaining -= take;
+                }
+            }
+            player.getInventory().setContents(contents);
+        }
+        player.updateInventory();
+    }
+
+    public void broadcastForgeAnnouncement(Player player, RelicType relic) {
+        String message = messages.format("relic.fragment.broadcast", Map.of(
+                "player", player.getName(),
+                "relic", relic.getDisplayName()
+        ));
+        Bukkit.broadcast(Component.text(message, NamedTextColor.GOLD));
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/LoreFragmentRecipe.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/LoreFragmentRecipe.java
@@ -1,0 +1,33 @@
+package me.j17e4eo.mythof5.relic;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Defines a required set of lore fragments and the resulting relic type.
+ */
+public final class LoreFragmentRecipe {
+
+    private final Set<LoreFragmentType> ingredients;
+    private final RelicType result;
+    private final String description;
+
+    public LoreFragmentRecipe(Set<LoreFragmentType> ingredients, RelicType result, String description) {
+        this.ingredients = EnumSet.copyOf(ingredients);
+        this.result = result;
+        this.description = description;
+    }
+
+    public Set<LoreFragmentType> getIngredients() {
+        return Collections.unmodifiableSet(ingredients);
+    }
+
+    public RelicType getResult() {
+        return result;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/LoreFragmentType.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/LoreFragmentType.java
@@ -1,0 +1,49 @@
+package me.j17e4eo.mythof5.relic;
+
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * Enumerates the collectible lore fragments used for advanced relic forging.
+ */
+public enum LoreFragmentType {
+    EMBER("ember", "불씨 조각", NamedTextColor.GOLD),
+    SHADOW("shadow", "그림자 조각", NamedTextColor.DARK_PURPLE),
+    TIDE("tide", "조류 조각", NamedTextColor.AQUA),
+    GALE("gale", "질풍 조각", NamedTextColor.GREEN),
+    STONE("stone", "바위 조각", NamedTextColor.GRAY);
+
+    private final String key;
+    private final String displayName;
+    private final NamedTextColor color;
+
+    LoreFragmentType(String key, String displayName, NamedTextColor color) {
+        this.key = key;
+        this.displayName = displayName;
+        this.color = color;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public NamedTextColor getColor() {
+        return color;
+    }
+
+    public static LoreFragmentType fromKey(String token) {
+        if (token == null) {
+            return null;
+        }
+        String normalized = token.trim().toLowerCase();
+        for (LoreFragmentType type : values()) {
+            if (type.key.equals(normalized) || type.displayName.equalsIgnoreCase(token)) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicAbility.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicAbility.java
@@ -1,0 +1,12 @@
+package me.j17e4eo.mythof5.relic;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Behaviour invoked when a relic is granted or removed.
+ */
+public interface RelicAbility {
+    void onGrant(Player player);
+
+    void onRemove(Player player);
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicManager.java
@@ -1,43 +1,208 @@
 package me.j17e4eo.mythof5.relic;
 
 import me.j17e4eo.mythof5.Mythof5;
+import me.j17e4eo.mythof5.balance.BalanceTable;
 import me.j17e4eo.mythof5.chronicle.ChronicleEventType;
 import me.j17e4eo.mythof5.chronicle.ChronicleManager;
 import me.j17e4eo.mythof5.config.Messages;
+import me.j17e4eo.mythof5.inherit.skilltree.SkillTreeManager;
+import me.j17e4eo.mythof5.meta.MetaEventManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.AreaEffectCloud;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerToggleSneakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Manages relic ownership, granting and fusion logic.
  */
-public class RelicManager {
+public class RelicManager implements Listener {
 
     private final Mythof5 plugin;
     private final Messages messages;
     private final ChronicleManager chronicleManager;
+    private final BalanceTable balanceTable;
+    private final SkillTreeManager skillTreeManager;
+    private final MetaEventManager metaEventManager;
     private final Map<UUID, Set<RelicType>> relics = new HashMap<>();
     private final List<RelicFusion> fusions = new ArrayList<>();
+    private final Map<RelicType, RelicAbility> abilities = new EnumMap<>(RelicType.class);
+    private final Map<UUID, Long> gumihoCooldown = new HashMap<>();
     private File dataFile;
     private YamlConfiguration dataConfig;
 
-    public RelicManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager) {
+    public RelicManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager,
+                        BalanceTable balanceTable, SkillTreeManager skillTreeManager,
+                        MetaEventManager metaEventManager) {
         this.plugin = plugin;
         this.messages = messages;
         this.chronicleManager = chronicleManager;
+        this.balanceTable = balanceTable;
+        this.skillTreeManager = skillTreeManager;
+        this.metaEventManager = metaEventManager;
         fusions.add(new RelicFusion(RelicType.TRICK_AND_BIND,
                 "환영과 포획이 동시에 발현되는 강력한 설화",
                 RelicType.MANGTAE_HALABEOM, RelicType.DUNGAP_MOUSE));
+        registerAbilities();
+    }
+
+    private void registerAbilities() {
+        abilities.put(RelicType.MANGTAE_HALABEOM, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.RESISTANCE, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.RESISTANCE);
+            }
+        });
+        abilities.put(RelicType.WATER_GOBLIN, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.CONDUIT_POWER, 0);
+                applyPermanentEffect(player, PotionEffectType.DOLPHINS_GRACE, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.CONDUIT_POWER);
+                player.removePotionEffect(PotionEffectType.DOLPHINS_GRACE);
+            }
+        });
+        abilities.put(RelicType.DUNGAP_MOUSE, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.SPEED, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.SPEED);
+            }
+        });
+        abilities.put(RelicType.PACK_ELDER, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.LUCK, 0);
+                applyPermanentEffect(player, PotionEffectType.HASTE, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.LUCK);
+                player.removePotionEffect(PotionEffectType.HASTE);
+            }
+        });
+        abilities.put(RelicType.DOOR_GUARD, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.RESISTANCE, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.RESISTANCE);
+            }
+        });
+        abilities.put(RelicType.GUMIHO_TAIL, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.SPEED, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.SPEED);
+            }
+        });
+        abilities.put(RelicType.TRICK_AND_BIND, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.INVISIBILITY, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.INVISIBILITY);
+            }
+        });
+        abilities.put(RelicType.TWILIGHT_CINDERS, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.NIGHT_VISION, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.NIGHT_VISION);
+            }
+        });
+        abilities.put(RelicType.STORMCALLER_DRUM, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.HERO_OF_THE_VILLAGE, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.HERO_OF_THE_VILLAGE);
+            }
+        });
+        abilities.put(RelicType.FORGE_HEART, new RelicAbility() {
+            @Override
+            public void onGrant(Player player) {
+                applyPermanentEffect(player, PotionEffectType.FIRE_RESISTANCE, 0);
+            }
+
+            @Override
+            public void onRemove(Player player) {
+                player.removePotionEffect(PotionEffectType.FIRE_RESISTANCE);
+            }
+        });
+    }
+
+    private void applyPermanentEffect(Player player, PotionEffectType type, int amplifier) {
+        PotionEffect effect = new PotionEffect(type, Integer.MAX_VALUE, amplifier, true, false, true);
+        player.addPotionEffect(effect);
     }
 
     public void load() {
@@ -92,16 +257,28 @@ public class RelicManager {
         if (!owned.add(type)) {
             return false;
         }
+        RelicAbility ability = abilities.get(type);
+        if (ability != null) {
+            ability.onGrant(player);
+        }
         if (announce) {
             player.sendMessage(messages.format("relic.obtain.self", Map.of(
                     "relic", type.getDisplayName(),
-                    "effect", type.getEffect()
+                    "effect", type.getEffect(),
+                    "rarity", type.getRarity().getDisplayName(),
+                    "ability", type.getAbility()
             )));
             plugin.broadcast(messages.format("relic.obtain.broadcast", Map.of(
                     "player", player.getName(),
                     "relic", type.getDisplayName()
             )));
         }
+        balanceTable.recordRelicEquipped(type);
+        skillTreeManager.addPoints(player.getUniqueId(), 1,
+                messages.format("goblin.skilltree.reason.relic", Map.of(
+                        "relic", type.getDisplayName()
+                )));
+        metaEventManager.recordRelicGain(type);
         chronicleManager.logEvent(ChronicleEventType.RELIC_GAIN,
                 messages.format("chronicle.relic.obtain", Map.of(
                         "player", player.getName(),
@@ -119,6 +296,10 @@ public class RelicManager {
         }
         boolean removed = owned.remove(type);
         if (removed) {
+            RelicAbility ability = abilities.get(type);
+            if (ability != null) {
+                ability.onRemove(player);
+            }
             save();
         }
         return removed;
@@ -139,9 +320,28 @@ public class RelicManager {
         }
         List<String> result = new ArrayList<>();
         for (RelicType type : owned) {
-            result.add("• " + type.getDisplayName() + " - " + type.getEffect());
+            result.add("• " + type.getDisplayName() + " [" + type.getRarity().getDisplayName() + "] - "
+                    + type.getAbility() + " / " + type.getSynergy());
         }
         return result;
+    }
+
+    public boolean hasRelic(UUID uuid, RelicType type) {
+        Set<RelicType> set = relics.get(uuid);
+        return set != null && set.contains(type);
+    }
+
+    public void handleJoin(Player player) {
+        Set<RelicType> set = relics.get(player.getUniqueId());
+        if (set == null) {
+            return;
+        }
+        for (RelicType type : set) {
+            RelicAbility ability = abilities.get(type);
+            if (ability != null) {
+                ability.onGrant(player);
+            }
+        }
     }
 
     private void checkFusions(Player player, Set<RelicType> owned) {
@@ -161,7 +361,165 @@ public class RelicManager {
                                 "player", player.getName(),
                                 "relic", fusion.getResult().getDisplayName()
                         )), List.of(player));
+                metaEventManager.recordRelicFusion(fusion.getResult());
             }
         }
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        handleJoin(event.getPlayer());
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onSneak(PlayerToggleSneakEvent event) {
+        if (!event.isSneaking()) {
+            return;
+        }
+        Player player = event.getPlayer();
+        if (hasRelic(player.getUniqueId(), RelicType.DUNGAP_MOUSE)) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 80, 0, true, true, true));
+            player.getWorld().spawnParticle(Particle.CLOUD, player.getLocation(), 12, 0.3, 0.5, 0.3, 0.02);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player player)) {
+            return;
+        }
+        double finalHealth = player.getHealth() - event.getFinalDamage();
+        if (hasRelic(player.getUniqueId(), RelicType.MANGTAE_HALABEOM)) {
+            double max = player.getAttribute(Attribute.MAX_HEALTH).getValue();
+            if (finalHealth <= max * 0.3D) {
+                player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 100, 1, true, true, true));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, 100, 1, true, true, true));
+                player.getWorld().spawnParticle(Particle.END_ROD, player.getLocation().add(0, 1, 0), 20, 0.4, 0.6, 0.4, 0.01);
+                player.playSound(player.getLocation(), Sound.ITEM_SHIELD_BLOCK, 1.0F, 0.7F);
+            }
+        }
+        if (hasRelic(player.getUniqueId(), RelicType.FORGE_HEART)) {
+            player.getWorld().spawnParticle(Particle.FLAME, player.getLocation().add(0, 0.5, 0), 30, 0.4, 0.4, 0.4, 0.02);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.STRENGTH, 80, 0, true, true, true));
+        }
+        if (hasRelic(player.getUniqueId(), RelicType.GUMIHO_TAIL)) {
+            long now = System.currentTimeMillis();
+            long next = gumihoCooldown.getOrDefault(player.getUniqueId(), 0L);
+            if (now >= next) {
+                spawnGumihoIllusion(player);
+                gumihoCooldown.put(player.getUniqueId(), now + 5000L);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDamageByEntity(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player player)) {
+            return;
+        }
+        Entity victim = event.getEntity();
+        if (!(victim instanceof LivingEntity living)) {
+            return;
+        }
+        if (hasRelic(player.getUniqueId(), RelicType.TWILIGHT_CINDERS)) {
+            living.setFireTicks(80);
+            if (living instanceof Player targetPlayer) {
+                targetPlayer.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 60, 0, true, true, true));
+            }
+            living.getWorld().spawnParticle(Particle.CAMPFIRE_SIGNAL_SMOKE, living.getLocation().add(0, 1, 0), 20, 0.3, 0.5, 0.3, 0.02);
+        }
+        if (hasRelic(player.getUniqueId(), RelicType.TRICK_AND_BIND)) {
+            living.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 60, 1, true, true, true));
+            living.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 60, 0, true, true, true));
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        Player player = event.getPlayer();
+        if (hasRelic(player.getUniqueId(), RelicType.STORMCALLER_DRUM)) {
+            activateStormcaller(player);
+        }
+        if (event.getClickedBlock() != null && hasRelic(player.getUniqueId(), RelicType.DOOR_GUARD)) {
+            String typeName = event.getClickedBlock().getType().name();
+            if (typeName.endsWith("DOOR") || typeName.contains("TRAPDOOR")) {
+                event.setCancelled(true);
+                player.playSound(event.getClickedBlock().getLocation(), Sound.BLOCK_IRON_DOOR_CLOSE, 1.0F, 0.8F);
+                deployDoorBarrier(player, event.getClickedBlock().getLocation());
+            }
+        }
+    }
+
+    private void activateStormcaller(Player player) {
+        Location center = player.getLocation();
+        player.getWorld().playSound(center, Sound.ITEM_TRIDENT_THUNDER, 1.0F, 1.2F);
+        player.getWorld().spawnParticle(Particle.CLOUD, center.add(0, 1, 0), 60, 4.0, 1.0, 4.0, 0.1);
+        double radius = 8.0D;
+        for (Entity entity : player.getWorld().getNearbyEntities(center, radius, radius, radius)) {
+            if (entity instanceof Player other) {
+                if (other.equals(player) || other.getUniqueId().equals(player.getUniqueId())) {
+                    other.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 100, 1, true, true, true));
+                } else {
+                    other.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 80, 0, true, true, true));
+                }
+            }
+        }
+    }
+
+    private void spawnGumihoIllusion(Player player) {
+        Location location = player.getLocation();
+        player.getWorld().spawnParticle(Particle.END_ROD, location, 40, 0.7, 0.6, 0.7, 0.03);
+        player.playSound(location, Sound.ENTITY_ENDERMAN_TELEPORT, 0.6F, 1.4F);
+        player.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 60, 0, true, true, true));
+        for (int i = 0; i < 3; i++) {
+            Location spawn = location.clone().add((i - 1) * 0.8, 0.1, ThreadLocalRandom.current().nextDouble(-0.4, 0.4));
+            ArmorStand stand = player.getWorld().spawn(spawn, ArmorStand.class, armorStand -> {
+                armorStand.setSmall(true);
+                armorStand.setArms(true);
+                armorStand.setGravity(false);
+                armorStand.setBasePlate(false);
+                armorStand.setInvulnerable(true);
+                armorStand.setPersistent(false);
+                armorStand.customName(Component.text(player.getName(), NamedTextColor.GOLD));
+                armorStand.setCustomNameVisible(true);
+                armorStand.setGlowing(true);
+                armorStand.getEquipment().setHelmet(createPlayerHead(player));
+            });
+            Vector velocity = player.getLocation().getDirection().clone()
+                    .rotateAroundY((i - 1) * 0.8).multiply(0.4);
+            stand.setVelocity(velocity);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                if (stand.isValid()) {
+                    stand.getEquipment().setHelmet(null);
+                    stand.remove();
+                }
+            }, 60L);
+        }
+    }
+
+    private void deployDoorBarrier(Player player, Location location) {
+        Location center = location.clone().add(0.5, 0.5, 0.5);
+        player.getWorld().spawnParticle(Particle.END_ROD, center, 50, 1.0, 0.3, 1.0, 0.02);
+        player.playSound(center, Sound.BLOCK_BEACON_ACTIVATE, 0.8F, 0.9F);
+        AreaEffectCloud cloud = player.getWorld().spawn(center, AreaEffectCloud.class);
+        cloud.setRadius(3.0F);
+        cloud.setDuration(100);
+        cloud.setRadiusPerTick(-0.03F);
+        cloud.addCustomEffect(new PotionEffect(PotionEffectType.SLOWNESS, 60, 1, false, true, true), true);
+        cloud.setWaitTime(5);
+    }
+
+    private ItemStack createPlayerHead(Player player) {
+        ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        ItemMeta meta = head.getItemMeta();
+        if (meta instanceof SkullMeta skullMeta) {
+            skullMeta.setOwningPlayer(player);
+            skullMeta.displayName(Component.text(player.getName(), NamedTextColor.GOLD));
+            head.setItemMeta(skullMeta);
+        }
+        return head;
     }
 }

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicRarity.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicRarity.java
@@ -1,0 +1,29 @@
+package me.j17e4eo.mythof5.relic;
+
+import net.kyori.adventure.text.format.NamedTextColor;
+
+/**
+ * Rarity tier for relics.
+ */
+public enum RelicRarity {
+    COMMON("일반", NamedTextColor.WHITE),
+    RARE("희귀", NamedTextColor.BLUE),
+    LEGENDARY("전설", NamedTextColor.GOLD),
+    MYTHIC("신화", NamedTextColor.LIGHT_PURPLE);
+
+    private final String displayName;
+    private final NamedTextColor color;
+
+    RelicRarity(String displayName, NamedTextColor color) {
+        this.displayName = displayName;
+        this.color = color;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public NamedTextColor getColor() {
+        return color;
+    }
+}

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicType.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/relic/RelicType.java
@@ -6,22 +6,42 @@ import java.util.Locale;
  * The smaller tales (설화) used as tactical relics on the server.
  */
 public enum RelicType {
-    MANGTAE_HALABEOM("mangtae_halabeom", "망태할아범", "단시간 상대를 포획해 묶어둔다."),
-    WATER_GOBLIN("water_goblin", "물도깨비", "수중 전투에서 이동과 호흡이 강화된다."),
-    GUMIHO_TAIL("gumiho_tail", "구미호 꼬리", "환영 분신을 만들어 교란한다."),
-    DOOR_GUARD("door_guard", "문지기 도깨비", "문과 포탈을 봉인하여 추격을 저지한다."),
-    DUNGAP_MOUSE("dungap_mouse", "둔갑쥐", "작은 동물로 둔갑해 위기를 모면한다."),
-    PACK_ELDER("pack_elder", "등짐 노인", "자원을 빠르게 운반하고 획득 효율을 높인다."),
-    TRICK_AND_BIND("trick_and_bind", "속임과 구속의 설화", "환영으로 적을 유인하고 동시에 결박한다.");
+    MANGTAE_HALABEOM("mangtae_halabeom", "망태할아범", "단시간 상대를 포획해 묶어둔다.",
+            RelicRarity.RARE, "30% 이하 체력일 때 방패막이 발동", "파워 계열과 시너지"),
+    WATER_GOBLIN("water_goblin", "물도깨비", "수중 전투에서 이동과 호흡이 강화된다.",
+            RelicRarity.RARE, "물속 이동속도 및 호흡 무한", "속도 계열과 시너지"),
+    GUMIHO_TAIL("gumiho_tail", "구미호 꼬리", "환영 분신을 만들어 교란한다.",
+            RelicRarity.LEGENDARY, "분신을 소환해 적의 시선을 끈다", "장난 계열과 시너지"),
+    DOOR_GUARD("door_guard", "문지기 도깨비", "문과 포탈을 봉인하여 추격을 저지한다.",
+            RelicRarity.RARE, "문과 게이트를 잠그는 역장 생성", "수비형 루트"),
+    DUNGAP_MOUSE("dungap_mouse", "둔갑쥐", "작은 동물로 둔갑해 위기를 모면한다.",
+            RelicRarity.COMMON, "은신과 이동 속도가 소폭 상승", "생존 루트"),
+    PACK_ELDER("pack_elder", "등짐 노인", "자원을 빠르게 운반하고 획득 효율을 높인다.",
+            RelicRarity.COMMON, "인벤토리 가방 슬롯 9칸 추가", "채집 루트"),
+    TRICK_AND_BIND("trick_and_bind", "속임과 구속의 설화", "환영으로 적을 유인하고 동시에 결박한다.",
+            RelicRarity.LEGENDARY, "표식 대상에게 속박 사슬 생성", "장난/파워 복합"),
+    TWILIGHT_CINDERS("twilight_cinders", "황혼의 잔불", "불씨와 그림자가 어우러진 칼날.",
+            RelicRarity.MYTHIC, "저체력 적에게 연소+실명 부여", "화염/장난 하이브리드"),
+    STORMCALLER_DRUM("stormcaller_drum", "폭풍을 부르는 북", "파도와 바람의 힘이 깃든 악기.",
+            RelicRarity.LEGENDARY, "북을 두드리면 광역 속도/둔화 발동", "속도/수호 하이브리드"),
+    FORGE_HEART("forge_heart", "단조의 심장", "대장장이 도깨비의 숨결이 남은 심장.",
+            RelicRarity.MYTHIC, "철갑 보호막과 도깨비불 폭발", "화염/대장간 하이브리드");
 
     private final String key;
     private final String displayName;
     private final String effect;
+    private final RelicRarity rarity;
+    private final String ability;
+    private final String synergy;
 
-    RelicType(String key, String displayName, String effect) {
+    RelicType(String key, String displayName, String effect,
+              RelicRarity rarity, String ability, String synergy) {
         this.key = key;
         this.displayName = displayName;
         this.effect = effect;
+        this.rarity = rarity;
+        this.ability = ability;
+        this.synergy = synergy;
     }
 
     public String getKey() {
@@ -34,6 +54,18 @@ public enum RelicType {
 
     public String getEffect() {
         return effect;
+    }
+
+    public RelicRarity getRarity() {
+        return rarity;
+    }
+
+    public String getAbility() {
+        return ability;
+    }
+
+    public String getSynergy() {
+        return synergy;
     }
 
     public static RelicType fromKey(String token) {

--- a/mythof5/src/main/resources/config.yml
+++ b/mythof5/src/main/resources/config.yml
@@ -43,6 +43,9 @@ movement:
     enabled: true
     vertical_velocity: 0.9
     forward_multiplier: 0.6
+relic:
+  fragments:
+    drop_chance: 0.01
 hunter:
   release:
     low: 0.0052

--- a/mythof5/src/main/resources/messages.yml
+++ b/mythof5/src/main/resources/messages.yml
@@ -230,6 +230,9 @@ goblin:
     - "{label} info"
     - "{label} skills [갈래]"
     - "{label} skill <스킬코드>"
+    - "{label} tree [갈래]"
+    - "{label} upgrade <스킬코드> <강화ID>"
+    - "{label} points"
     - "{label} progress"
     - "{label} share <갈래> <플레이어>"
     - "{label} reclaim <갈래> <플레이어>"
@@ -274,6 +277,27 @@ goblin:
     none: "아직 계승자가 없다"
   passive:
     scent: "주변 기척 {count}건이 감지되었다."
+    scent_reader: "주변의 발자취가 일렁이며 기척을 드러낸다."
+    stagger_guard: "경직의 충격이 사라지고 몸이 다시 움직이기 시작한다!"
+  skilltree:
+    usage: "사용법: /goblin upgrade <스킬코드> <강화ID>"
+    header: "남은 강화 포인트: {points}"
+    skill: "- {name} ({key})"
+    none: "  · 아직 선택한 강화가 없습니다."
+    option: "  · {id}: {name} (비용 {cost}) - {desc}"
+    already: "이미 해당 스킬의 강화를 선택했습니다."
+    not_enough: "강화 포인트가 부족합니다."
+    unknown_skill: "해당 스킬을 찾을 수 없습니다."
+    aspect_missing: "{aspect}의 힘을 계승하거나 공유받아야 합니다."
+    unknown_upgrade: "해당 강화는 존재하지 않습니다."
+    unlocked: "{skill}의 {upgrade} 강화를 개방했습니다!"
+    gain: "강화 포인트 {points}점을 획득했습니다! ({reason})"
+    points: "현재 강화 포인트: {points}"
+    title: "[{aspect}] 스킬 트리"
+    reason:
+      unknown: "기록되지 않은 공적"
+      boss: "{boss} 격파"
+      relic: "설화 {relic} 회수"
   progress:
     header: "===== 다섯 갈래 진행도 ====="
     power:
@@ -345,6 +369,7 @@ relic:
     - "{label} help"
     - "{label} list"
     - "{label} fusions"
+    - "{label} forge"
   obtain:
     self: "새 설화 '{relic}'을(를) 발견했다! 효과: {effect}"
     broadcast: "[방송] {player}가 설화 '{relic}'을(를) 획득했다!"
@@ -356,6 +381,12 @@ relic:
     none: "알려진 설화 융합이 없습니다."
   none: "보유한 설화가 없습니다."
   unknown: "알 수 없는 설화입니다."
+  fragment:
+    drop: "희미한 설화 조각이 떨어졌다: {type}"
+    lore: "도깨비 장인에게 가져가면 새로운 설화를 만들 수 있을 것 같다."
+    forge_success: "설화 조각이 공명하여 {relic}(이)가 탄생했다! {desc}"
+    forge_fail: "필요한 설화 조각 조합을 아직 모으지 못했다."
+    broadcast: "[방송] {player}가 설화 조각을 모아 {relic}(을)를 완성했다!"
 chronicle:
   empty: "아직 연대기에 기록된 사건이 없다."
   default:
@@ -382,6 +413,8 @@ chronicle:
     fusion: "{player}, 설화를 얽어 '{relic}'을 빚어냈도다."
   skill:
     use: "{player}, {aspect}의 권능 '{skill}'을 펼쳤도다."
+    point: "{player}, 도깨비 기술을 연마해 강화 포인트 {points}을 얻었도다. ({reason})"
+    upgrade: "{player}, '{skill}'의 강화 '{upgrade}'을 개방하였도다."
   omen: "{stage}의 전조가 드러났으니, {reason}라 하도다."
   inherit_loss: "{player}, {aspect}과의 인연이 끊어졌도다."
   hunter:
@@ -418,6 +451,16 @@ commands.admin:
   omen_usage: "사용법: /myth admin omen <STARSHIFT|GHOST_FIRE|SKYBREAK> [사유]"
   omen_unknown: "알 수 없는 전조 단계입니다."
   omen_triggered: "{stage} 전조를 호출했습니다. 사유: {reason}"
+  balance_hint: "/myth admin balance report 또는 export 로 상세 통계를 확인하세요."
+  balance_export: "밸런스 리포트를 {path} 파일로 내보냈습니다."
+  balance_export_fail: "밸런스 리포트 내보내기에 실패했습니다."
+  balance_unknown: "알 수 없는 밸런스 하위 명령입니다."
+
+events:
+  balance_collapse:
+    start: "{skill}이(가) 과도하게 사용되며 균형 붕괴가 시작된다! 몬스터가 분노한다."
+  lore_fracture:
+    start: "설화의 균열이 일어나 조각이 흩어진다! {relic}의 전설이 요동친다."
 omen:
   starshift: "[전조] 별자리가 뒤틀리며 속삭임이 들려온다."
   ghost_fire: "[전조] 도깨비불이 들판을 가득 메우기 시작한다."


### PR DESCRIPTION
## Summary
- wire new skill metadata, passive trigger logic, and area/status/environment handling into AspectManager and goblin skills
- add a full skill tree manager with commands, balance tracking upgrades, and chronicle messages
- expand relic system with rarities, active abilities, lore fragments, meta events, and updated admin/balance tooling
- update messages/config defaults for new systems and register managers/listeners in Mythof5 lifecycle

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cd8647be8883249ab73b8ddc0a00fd