### PR TITLE
Prevent inheritors from becoming hunters

### DIFF
--- a/mythof5/src/main/java/me/j17e4eo/mythof5/Mythof5.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/Mythof5.java
@@ -135,9 +135,14 @@ public final class Mythof5 extends JavaPlugin {
                 sealPatchValue, deathDecay, witnessRadius, broadcastCooldownMillis,
                 longThreshold, mediumThreshold, lateThreshold, gaugeOverrides);
         hunterManager.load();
+        hunterManager.setAspectManager(aspectManager);
+        hunterManager.setInheritManager(inheritManager);
         aspectManager.setHunterManager(hunterManager);
 
         sealManager = new SealManager(this, messages, hunterManager, aspectManager);
+        aspectManager.setSealManager(sealManager);
+        inheritManager.setHunterManager(hunterManager);
+        inheritManager.setSealManager(sealManager);
 
         long ritualWindow = getConfig().getLong("hunter.paradox.ritual_window", 600L);
         double failureScale = getConfig().getDouble("hunter.paradox.failure_scale", 1.5D);

--- a/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/HunterManager.java
+++ b/mythof5/src/main/java/me/j17e4eo/mythof5/hunter/HunterManager.java
@@ -13,6 +13,8 @@ import me.j17e4eo.mythof5.hunter.data.ArtifactType;
 import me.j17e4eo.mythof5.hunter.data.HunterOmenStage;
 import me.j17e4eo.mythof5.hunter.data.HunterProfile;
 import me.j17e4eo.mythof5.hunter.data.SealLogEntry;
+import me.j17e4eo.mythof5.inherit.AspectManager;
+import me.j17e4eo.mythof5.inherit.InheritManager;
 import me.j17e4eo.mythof5.hunter.event.HunterReleaseEvent;
 import me.j17e4eo.mythof5.hunter.math.SealMath;
 import me.j17e4eo.mythof5.hunter.test.HunterTestHook;
@@ -62,6 +64,8 @@ public class HunterManager {
     private YamlConfiguration dataConfig;
     private long lastBroadcast;
     private ParadoxManager paradoxManager;
+    private InheritManager inheritManager;
+    private AspectManager aspectManager;
 
     public HunterManager(Mythof5 plugin, Messages messages, ChronicleManager chronicleManager, SealMath sealMath,
                          double sealPatchValue, double deathIntegrityDecay, double witnessRadius,
@@ -83,6 +87,14 @@ public class HunterManager {
 
     public void setParadoxManager(ParadoxManager paradoxManager) {
         this.paradoxManager = paradoxManager;
+    }
+
+    public void setInheritManager(InheritManager inheritManager) {
+        this.inheritManager = inheritManager;
+    }
+
+    public void setAspectManager(AspectManager aspectManager) {
+        this.aspectManager = aspectManager;
     }
 
     public void load() {
@@ -195,6 +207,10 @@ public class HunterManager {
 
     public boolean acceptQuest(Player player) {
         HunterProfile profile = getProfile(player);
+        if (hasGoblinInheritance(player)) {
+            player.sendMessage(messages.format("hunter.error.is_inheritor"));
+            return false;
+        }
         if (profile.isQuestAccepted()) {
             player.sendMessage(messages.format("hunter.quest.already"));
             return false;
@@ -211,6 +227,10 @@ public class HunterManager {
         HunterProfile profile = getProfile(player);
         if (!profile.isQuestAccepted()) {
             player.sendMessage(messages.format("hunter.quest.not_ready"));
+            return false;
+        }
+        if (hasGoblinInheritance(player)) {
+            player.sendMessage(messages.format("hunter.error.is_inheritor"));
             return false;
         }
         if (profile.isEngraved()) {
@@ -535,6 +555,14 @@ public class HunterManager {
         if (paradoxManager != null) {
             paradoxManager.shutdown();
         }
+    }
+
+    private boolean hasGoblinInheritance(Player player) {
+        UUID uuid = player.getUniqueId();
+        if (inheritManager != null && inheritManager.isInheritor(uuid)) {
+            return true;
+        }
+        return aspectManager != null && aspectManager.isInheritorOfAnyAspect(uuid);
     }
 
     public record UseResult(double integrity, double chance, double roll, boolean release, double fatigue) {

--- a/mythof5/src/main/resources/messages.yml
+++ b/mythof5/src/main/resources/messages.yml
@@ -160,6 +160,7 @@ hunter:
     ability_not_found: "해당 능력은 매개체에 봉인되어 있지 않다."
     patch_broken: "붕괴된 매개체에는 봉인지를 사용할 수 없다."
     no_profile: "기록된 사냥꾼이 없다."
+    is_inheritor: "도깨비 계승자는 사냥꾼의 길을 택할 수 없습니다."
     invalid_number: "숫자 형식이 올바르지 않다."
     invalid_uuid: "올바른 ID 형식이 아니다."
     no_paradox: "역설 의식을 제어할 도구가 아직 준비되지 않았다."


### PR DESCRIPTION
## Summary
- block the hunter quest and engraving steps when a player already holds goblin inheritance
- stop transferring goblin aspects to hunters on kill and drop a sealable flame instead
- wire managers together and add messaging so hunters must seal flames to gain non-transformation powers

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68ce12b24bf88324af8ad79e44fc11d2